### PR TITLE
Security Hardening: env validation, security headers, rate limits, and graceful shutdown

### DIFF
--- a/apps/api/bun.lock
+++ b/apps/api/bun.lock
@@ -15,6 +15,7 @@
         "drizzle-orm": "^0.45.1",
         "express": "^5.2.1",
         "express-rate-limit": "^8.3.1",
+        "helmet": "^8.3.0",
         "pino": "^10.3.1",
         "pino-http": "^11.0.0",
         "zod": "^4.3.6",
@@ -433,6 +434,8 @@
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "helmet": ["helmet@8.3.0", "", {}, "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w=="],
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,6 +38,7 @@
     "drizzle-orm": "^0.45.1",
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.1",
+    "helmet": "^8.3.0",
     "pino": "^10.3.1",
     "pino-http": "^11.0.0",
     "zod": "^4.3.6"

--- a/apps/api/src/commons/middlewares/helmet.ts
+++ b/apps/api/src/commons/middlewares/helmet.ts
@@ -1,0 +1,23 @@
+import helmet from "helmet";
+
+/**
+ * Interis's API is pure JSON with no server-rendered HTML/JS/assets, so the
+ * CSP can be maximally restrictive — nothing this API returns is ever meant
+ * to be loaded as a document, script, or embedded frame.
+ */
+export const helmetMiddleware = helmet({
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'none'"],
+      frameAncestors: ["'none'"],
+      baseUri: ["'none'"],
+      formAction: ["'none'"],
+    },
+  },
+  frameguard: { action: "deny" },
+  referrerPolicy: { policy: "strict-origin-when-cross-origin" },
+  hsts: {
+    maxAge: 31536000,
+    includeSubDomains: true,
+  },
+});

--- a/apps/api/src/commons/middlewares/rateLimiters.ts
+++ b/apps/api/src/commons/middlewares/rateLimiters.ts
@@ -1,0 +1,39 @@
+import rateLimit, { type RateLimitRequestHandler } from "express-rate-limit";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+// Factories, not shared singletons — each createApp() call (one per test
+// server, one per running process) gets its own in-memory counters so
+// separate app instances never contaminate each other's rate-limit state.
+
+export const createAuthLimiter = (): RateLimitRequestHandler =>
+  rateLimit({
+    windowMs: 60 * 1000,
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
+export const createApiLimiter = (): RateLimitRequestHandler =>
+  rateLimit({
+    windowMs: 60 * 1000,
+    max: 300,
+    standardHeaders: true,
+    legacyHeaders: false,
+    // public.routes.ts already applies its own dedicated limiter.
+    skip: (req) => req.path.startsWith("/public/"),
+  });
+
+/**
+ * Extra ceiling on state-changing requests specifically, layered on top of
+ * apiLimiter, to blunt spam/brute-force writes (e.g. mass review/list
+ * creation) without throttling read-heavy browsing.
+ */
+export const createMutationLimiter = (): RateLimitRequestHandler =>
+  rateLimit({
+    windowMs: 60 * 1000,
+    max: 60,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: (req) => SAFE_METHODS.has(req.method),
+  });

--- a/apps/api/src/commons/middlewares/securityHeaders.ts
+++ b/apps/api/src/commons/middlewares/securityHeaders.ts
@@ -7,17 +7,11 @@ const permissionsPolicy = [
   "payment=()",
 ].join(", ");
 
+/**
+ * Sets Permissions-Policy — the one baseline security header Helmet does not
+ * set. All other headers (CSP, X-Frame-Options, HSTS, etc.) come from Helmet.
+ */
 export const securityHeaders: RequestHandler = (_req, res, next) => {
-  res.setHeader("X-Content-Type-Options", "nosniff");
-  res.setHeader("X-Frame-Options", "DENY");
-  res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
-  res.setHeader("X-DNS-Prefetch-Control", "off");
-  res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
   res.setHeader("Permissions-Policy", permissionsPolicy);
-
-  if (process.env.NODE_ENV === "production") {
-    res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
-  }
-
   next();
 };

--- a/apps/api/src/commons/utils/logger.ts
+++ b/apps/api/src/commons/utils/logger.ts
@@ -1,6 +1,7 @@
 import pino from "pino";
+import { env } from "../../infrastructure/config/env";
 
-const isProduction = process.env.NODE_ENV === "production";
+const isProduction = env.NODE_ENV === "production";
 
 export const logger = pino({
   level: isProduction ? "info" : "debug",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,13 +5,19 @@ import express, {
 } from "express";
 import cors from "cors";
 import pinoHttp from "pino-http";
-import rateLimit from "express-rate-limit";
 import { randomUUID } from "node:crypto";
 import { toNodeHandler } from "better-auth/node";
 import { auth } from "./infrastructure/auth/auth";
 import { logger } from "./commons/utils/logger";
+import { env } from "./infrastructure/config/env";
 import { securityHeaders } from "./commons/middlewares/securityHeaders";
+import { helmetMiddleware } from "./commons/middlewares/helmet";
 import { requireTrustedOriginForMutations } from "./commons/middlewares/requireTrustedOriginForMutations";
+import {
+  createAuthLimiter,
+  createApiLimiter,
+  createMutationLimiter,
+} from "./commons/middlewares/rateLimiters";
 import {
   getTrustedOriginsFromEnv,
   isTrustedOrigin,
@@ -33,23 +39,12 @@ import dataTransferRouter from "./modules/data-transfer/data-transfer.routes";
 export const createApp = () => {
   const app = express();
   const trustedOrigins = getTrustedOriginsFromEnv();
-
-  const authLimiter = rateLimit({
-    windowMs: 60 * 1000,
-    max: 30,
-    standardHeaders: true,
-    legacyHeaders: false,
-  });
-
-  const apiLimiter = rateLimit({
-    windowMs: 60 * 1000,
-    max: 300,
-    standardHeaders: true,
-    legacyHeaders: false,
-    skip: (req) => req.path.startsWith("/public/"),
-  });
+  const authLimiter = createAuthLimiter();
+  const apiLimiter = createApiLimiter();
+  const mutationLimiter = createMutationLimiter();
 
   app.disable("x-powered-by");
+  app.use(helmetMiddleware);
   app.use(securityHeaders);
 
   app.use(
@@ -98,8 +93,13 @@ export const createApp = () => {
   );
 
   app.use("/api", apiLimiter);
+  app.use("/api", mutationLimiter);
   app.use(requireTrustedOriginForMutations(trustedOrigins));
   app.use("/api/auth", authLimiter);
+  // Bounded JSON parsing ahead of the auth handler — Better Auth's node
+  // adapter reads req.body directly when Express has already parsed it, so
+  // this both enforces a size limit and works transparently.
+  app.use("/api/auth", express.json({ limit: "20kb" }));
   app.all("/api/auth/*splat", toNodeHandler(auth));
 
   app.use(express.json({ limit: "1mb" }));
@@ -133,6 +133,16 @@ export const createApp = () => {
       return;
     }
 
+    const bodyParserError = err as Error & { type?: string; status?: number };
+    if (bodyParserError.type === "entity.too.large") {
+      res.status(413).json({ error: "Request body too large" });
+      return;
+    }
+    if (bodyParserError.type?.startsWith("entity.parse")) {
+      res.status(400).json({ error: "Malformed request body" });
+      return;
+    }
+
     logger.error(err);
     res.status(500).json({ error: "Internal server error" });
   });
@@ -142,11 +152,29 @@ export const createApp = () => {
 
 export const startServer = () => {
   const app = createApp();
-  const port = Number(process.env.PORT ?? 3000);
+  const port = env.PORT;
 
-  return app.listen(port, () => {
+  const server = app.listen(port, () => {
     logger.info(`🚀 Express server running on http://localhost:${port}`);
   });
+
+  const shutdown = (signal: string) => {
+    logger.info(`${signal} received, shutting down gracefully`);
+    server.close((err) => {
+      if (err) {
+        logger.error(err, "Error while closing server");
+        process.exit(1);
+      }
+
+      logger.info("Server closed, exiting");
+      process.exit(0);
+    });
+  };
+
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+
+  return server;
 };
 
 if (import.meta.main) {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -158,7 +158,14 @@ export const startServer = () => {
     logger.info(`🚀 Express server running on http://localhost:${port}`);
   });
 
+  let isShuttingDown = false;
+
   const shutdown = (signal: string) => {
+    if (isShuttingDown) {
+      return;
+    }
+    isShuttingDown = true;
+
     logger.info(`${signal} received, shutting down gracefully`);
     server.close((err) => {
       if (err) {

--- a/apps/api/src/infrastructure/auth/auth.ts
+++ b/apps/api/src/infrastructure/auth/auth.ts
@@ -12,8 +12,9 @@ import {
   normalizeUsername,
 } from "../../modules/users/policies/username.policy";
 import { getTrustedOriginsFromEnv } from "../config/origins";
+import { env } from "../config/env";
 
-const isProduction = process.env.NODE_ENV === "production";
+const isProduction = env.NODE_ENV === "production";
 const trustedOrigins = getTrustedOriginsFromEnv();
 
 const getStringField = (
@@ -46,8 +47,8 @@ export const auth = betterAuth({
     },
   },
 
-  baseURL: process.env.BETTER_AUTH_URL,
-  secret: process.env.BETTER_AUTH_SECRET,
+  baseURL: env.BETTER_AUTH_URL,
+  secret: env.BETTER_AUTH_SECRET,
   trustedOrigins,
 
   plugins: [

--- a/apps/api/src/infrastructure/config/env.ts
+++ b/apps/api/src/infrastructure/config/env.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  NODE_ENV: z
+    .enum(["development", "production", "test"])
+    .default("development"),
+  PORT: z.coerce.number().int().positive().default(5000),
+  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+  BETTER_AUTH_URL: z.url("BETTER_AUTH_URL must be a valid URL"),
+  BETTER_AUTH_SECRET: z
+    .string()
+    .min(16, "BETTER_AUTH_SECRET must be at least 16 characters"),
+  TMDB_ACCESS_TOKEN: z.string().min(1, "TMDB_ACCESS_TOKEN is required"),
+  CORS_ORIGIN: z.string().optional(),
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+const formatIssues = (error: z.ZodError): string => {
+  return error.issues
+    .map((issue) => `  - ${issue.path.join(".") || "(root)"}: ${issue.message}`)
+    .join("\n");
+};
+
+const loadEnv = (): Env => {
+  const result = envSchema.safeParse(process.env);
+
+  if (!result.success) {
+    console.error(
+      `Invalid environment configuration:\n${formatIssues(result.error)}`,
+    );
+    process.exit(1);
+  }
+
+  return result.data;
+};
+
+export const env = loadEnv();

--- a/apps/api/src/infrastructure/config/origins.ts
+++ b/apps/api/src/infrastructure/config/origins.ts
@@ -1,3 +1,5 @@
+import { env } from "./env";
+
 const normalizeOrigin = (value: string): string => {
   return value.trim().replace(/\/+$/, "");
 };
@@ -17,7 +19,7 @@ const parseOriginFromValue = (value: string): string | null => {
 };
 
 export const getTrustedOriginsFromEnv = (): string[] => {
-  const rawOrigins = process.env.CORS_ORIGIN ?? "";
+  const rawOrigins = env.CORS_ORIGIN ?? "";
 
   const trustedOrigins = rawOrigins
     .split(",")

--- a/apps/api/src/infrastructure/database/db.ts
+++ b/apps/api/src/infrastructure/database/db.ts
@@ -1,10 +1,7 @@
 import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
+import { env } from "../config/env";
 import * as schema from "./entities";
 
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL is missing in .env");
-}
-
-const sql = neon(process.env.DATABASE_URL);
+const sql = neon(env.DATABASE_URL);
 export const db = drizzle(sql, { schema });

--- a/apps/api/tests/integration/security/body-size.test.ts
+++ b/apps/api/tests/integration/security/body-size.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+describe("request body size limits", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) {
+      return;
+    }
+
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("rejects an oversized auth payload with 413", async () => {
+    const response = await apiRequest(
+      getServer().baseUrl,
+      "/api/auth/sign-up/email",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ padding: "x".repeat(25_000) }),
+      },
+    );
+
+    expect(response.status).toBe(413);
+  });
+
+  it("rejects an oversized general JSON payload with 413", async () => {
+    const response = await apiRequest(getServer().baseUrl, "/api/reviews", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ padding: "x".repeat(1_100_000) }),
+    });
+
+    expect(response.status).toBe(413);
+  });
+});

--- a/apps/api/tests/integration/security/cors-csrf.test.ts
+++ b/apps/api/tests/integration/security/cors-csrf.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+import { getTrustedOriginsFromEnv } from "../../../src/infrastructure/config/origins";
+
+describe("CORS + CSRF origin enforcement", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) {
+      return;
+    }
+
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("rejects any request from an untrusted Origin", async () => {
+    const response = await apiRequest(getServer().baseUrl, "/api/health", {
+      headers: { origin: "https://evil.example.com" },
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects a mutation with an untrusted Origin (blocked by the CORS layer)", async () => {
+    const response = await apiRequest(
+      getServer().baseUrl,
+      "/api/__no_such_route__",
+      {
+        method: "POST",
+        headers: {
+          origin: "https://evil.example.com",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+    );
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("Origin is not allowed");
+  });
+
+  it("rejects a mutation with no Origin but an untrusted Referer", async () => {
+    // No Origin header means it clears the generic CORS layer — this
+    // exercises requireTrustedOriginForMutations' Referer fallback, which
+    // the CORS middleware alone does not check.
+    const response = await apiRequest(
+      getServer().baseUrl,
+      "/api/__no_such_route__",
+      {
+        method: "POST",
+        headers: {
+          referer: "https://evil.example.com/attack-page",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+    );
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("Invalid origin");
+  });
+
+  it("allows a mutation from a trusted Origin to reach routing", async () => {
+    const [trustedOrigin] = getTrustedOriginsFromEnv();
+    if (!trustedOrigin) {
+      throw new Error("No trusted origins configured");
+    }
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      "/api/__no_such_route__",
+      {
+        method: "POST",
+        headers: {
+          origin: trustedOrigin,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+    );
+
+    // Not 403 — origin was accepted, request just hit no matching route.
+    expect(response.status).not.toBe(403);
+  });
+});

--- a/apps/api/tests/integration/security/env-validation.test.ts
+++ b/apps/api/tests/integration/security/env-validation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const envFilePath = resolve(import.meta.dir, "../../../src/infrastructure/config/env.ts");
+// Bun auto-loads a .env from the child process's cwd regardless of the `env`
+// option passed to spawn — run outside the repo so apps/api/.env can't
+// silently backfill the vars this test is trying to omit.
+const cwdWithoutDotenv = tmpdir();
+
+describe("runtime env validation", () => {
+  it("exits 1 with a descriptive message when a required var is missing", async () => {
+    const { DATABASE_URL: _omitted, ...envWithoutDatabaseUrl } = process.env;
+
+    const proc = Bun.spawn({
+      cmd: ["bun", "run", envFilePath],
+      cwd: cwdWithoutDotenv,
+      env: envWithoutDatabaseUrl,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [exitCode, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stderr).text(),
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("DATABASE_URL");
+  });
+
+  it("exits 1 when BETTER_AUTH_URL is not a valid URL", async () => {
+    const proc = Bun.spawn({
+      cmd: ["bun", "run", envFilePath],
+      cwd: cwdWithoutDotenv,
+      env: { ...process.env, BETTER_AUTH_URL: "not-a-url" },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [exitCode, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stderr).text(),
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("BETTER_AUTH_URL");
+  });
+});

--- a/apps/api/tests/integration/security/headers.test.ts
+++ b/apps/api/tests/integration/security/headers.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+describe("security headers", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) {
+      return;
+    }
+
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("sets Helmet + Permissions-Policy headers on every response", async () => {
+    const response = await apiRequest(getServer().baseUrl, "/api/health");
+
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("x-frame-options")).toBe("DENY");
+    expect(response.headers.get("strict-transport-security")).toContain(
+      "max-age=31536000",
+    );
+    expect(response.headers.get("content-security-policy")).toContain(
+      "default-src 'none'",
+    );
+    expect(response.headers.get("permissions-policy")).toContain(
+      "camera=()",
+    );
+    expect(response.headers.get("x-powered-by")).toBeNull();
+  });
+});

--- a/apps/api/tests/integration/security/rate-limits.test.ts
+++ b/apps/api/tests/integration/security/rate-limits.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+describe("rate limiting", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) {
+      return;
+    }
+
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("returns 429 once the auth limiter's ceiling (30/min) is exceeded", async () => {
+    const statuses: number[] = [];
+
+    for (let i = 0; i < 31; i += 1) {
+      const response = await apiRequest(
+        getServer().baseUrl,
+        "/api/auth/get-session",
+      );
+      statuses.push(response.status);
+    }
+
+    expect(statuses.at(-1)).toBe(429);
+  });
+
+  it("returns 429 once the mutation limiter's ceiling (60/min) is exceeded", async () => {
+    const statuses: number[] = [];
+
+    for (let i = 0; i < 61; i += 1) {
+      const response = await apiRequest(
+        getServer().baseUrl,
+        "/api/__no_such_mutation_route__",
+        { method: "POST" },
+      );
+      statuses.push(response.status);
+    }
+
+    expect(statuses.at(-1)).toBe(429);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #14. Hardens the Express API layer with fail-fast startup validation, tighter HTTP security headers, additional rate limiting, bounded auth request bodies, and graceful shutdown.

- **Environment validation**: `infrastructure/config/env.ts` validates `DATABASE_URL`, `BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`, `TMDB_ACCESS_TOKEN`, `CORS_ORIGIN`, and `PORT` with Zod at startup, exiting with a descriptive error (code 1) instead of failing deep inside whichever module first touches `process.env`. `db.ts`, `auth.ts`, `origins.ts`, and `logger.ts` now read from the validated env.
- **Security headers**: added Helmet with a restrictive CSP (`default-src 'none'`) appropriate for a pure JSON API; `securityHeaders` now only owns `Permissions-Policy`, the one header Helmet doesn't set.
- **Rate limiting**: added a mutation-specific limiter (60/min, gated to non-safe HTTP methods) layered on the existing auth/API limiters. Converted limiters from module-level singletons to per-`createApp()` factories so separate app instances (notably parallel test servers) don't share counters.
- **Request body bounds**: auth routes now get bounded JSON parsing (20kb) ahead of the Better Auth handler. Verified via `better-call`'s node adapter source that it reads `req.body` directly when Express has already parsed it, so this doesn't interfere with auth.
- **Graceful shutdown**: `SIGTERM`/`SIGINT` now close the HTTP server cleanly before exit.
- **Error handling**: body-parser errors now return `413`/`400` instead of being masked as `500`.
- `.env` was already gitignored and untracked in git history — no cleanup needed there.

Also confirmed `public.routes.ts` already had its own dedicated rate limiter for `/api/public/*` — an earlier pass mistakenly assumed public routes were unprotected; that assumption was corrected before merging.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint:arch`
- [x] `bun test` (14/14 passing, including 11 new security tests covering headers, CORS/CSRF origin + Referer enforcement, rate-limit tripping, oversized-body rejection, and env-validation fail-fast)