### PR TITLE
Lists: fix reorder bug, paginate + cap collections, add test coverage

### DIFF
--- a/apps/api/src/modules/lists/constants/lists.constants.ts
+++ b/apps/api/src/modules/lists/constants/lists.constants.ts
@@ -1,0 +1,4 @@
+// A list is user-curated (searched + added one at a time), so this ceiling
+// is well above any realistic use — it exists purely to bound unbounded
+// growth from a buggy or abusive client hammering the add-item endpoint.
+export const MAX_LIST_ITEMS = 500;

--- a/apps/api/src/modules/lists/lists.service.ts
+++ b/apps/api/src/modules/lists/lists.service.ts
@@ -8,8 +8,17 @@ export class ListsService {
     publicOnly: boolean,
     checkTmdbId?: number,
     checkItemType?: string,
+    limit?: number,
+    offset?: number,
   ) {
-    return ListsReadService.getUserLists(userId, publicOnly, checkTmdbId, checkItemType);
+    return ListsReadService.getUserLists(
+      userId,
+      publicOnly,
+      checkTmdbId,
+      checkItemType,
+      limit,
+      offset,
+    );
   }
 
   static async getListDetail(listId: string, viewerUserId: string | null) {

--- a/apps/api/src/modules/lists/repositories/lists-read.repository.ts
+++ b/apps/api/src/modules/lists/repositories/lists-read.repository.ts
@@ -15,7 +15,12 @@ export class ListsReadRepository {
     return row ?? null;
   }
 
-  static async findByUserId(userId: string, publicOnly: boolean) {
+  static async findByUserId(
+    userId: string,
+    publicOnly: boolean,
+    limit?: number,
+    offset?: number,
+  ) {
     const query = db
       .select({
         id: lists.id,
@@ -37,9 +42,10 @@ export class ListsReadRepository {
           : eq(lists.userId, userId),
       )
       .groupBy(lists.id)
-      .orderBy(desc(lists.updatedAt));
+      .orderBy(desc(lists.updatedAt))
+      .$dynamic();
 
-    return query;
+    return limit ? query.limit(limit).offset(offset ?? 0) : query;
   }
 
   static async getCoverImages(listIds: string[]) {

--- a/apps/api/src/modules/lists/repositories/lists-write.repository.ts
+++ b/apps/api/src/modules/lists/repositories/lists-write.repository.ts
@@ -84,7 +84,7 @@ export class ListsWriteRepository {
     if (items.length === 0) return;
 
     const whenClauses = items.map(
-      (item) => sql`WHEN ${item.id}::uuid THEN ${item.position}`,
+      (item) => sql`WHEN ${item.id}::uuid THEN ${item.position}::integer`,
     );
 
     await db

--- a/apps/api/src/modules/lists/services/lists-read.service.ts
+++ b/apps/api/src/modules/lists/services/lists-read.service.ts
@@ -9,8 +9,19 @@ export class ListsReadService {
     publicOnly: boolean,
     checkTmdbId?: number,
     checkItemType?: string,
+    limit?: number,
+    offset?: number,
   ) {
-    const listRows = await ListsReadRepository.findByUserId(userId, publicOnly);
+    // Item-check mode (AddToListDialog) needs the complete set of the
+    // user's lists to render correct membership checkmarks — pagination
+    // only applies to the plain "browse my lists" mode.
+    const isItemCheckMode = checkTmdbId !== undefined && checkItemType !== undefined;
+    const listRows = await ListsReadRepository.findByUserId(
+      userId,
+      publicOnly,
+      isItemCheckMode ? undefined : limit,
+      isItemCheckMode ? undefined : offset,
+    );
 
     if (listRows.length === 0) {
       return [];

--- a/apps/api/src/modules/lists/services/lists-write.service.ts
+++ b/apps/api/src/modules/lists/services/lists-write.service.ts
@@ -1,12 +1,13 @@
 import { MoviesCacheService } from "../../movies/services/movies-cache.service";
 import { SerialsCacheService } from "../../serials/services/serials-cache.service";
 import { SocialRepository } from "../../social/repositories/social.repository";
+import { MAX_LIST_ITEMS } from "../constants/lists.constants";
 import type { CreateListDto, UpdateListDto } from "../dto/lists.dto";
 import { deriveListType } from "../helpers/derive-list-type.helper";
 import { ListsReadRepository } from "../repositories/lists-read.repository";
 import { ListsWriteRepository } from "../repositories/lists-write.repository";
 
-type ServiceError = { error: string; status: 403 | 404 };
+type ServiceError = { error: string; status: 400 | 403 | 404 };
 
 export class ListsWriteService {
   static async createList(userId: string, data: CreateListDto) {
@@ -92,6 +93,14 @@ export class ListsWriteService {
       return { error: "Forbidden", status: 403 };
     }
 
+    const currentTypes = await ListsReadRepository.getCurrentItemTypes(listId);
+    if (currentTypes.length >= MAX_LIST_ITEMS) {
+      return {
+        error: `Lists are limited to ${MAX_LIST_ITEMS} items`,
+        status: 400,
+      };
+    }
+
     let movieId: number | undefined;
     let tvSeriesId: number | undefined;
 
@@ -118,8 +127,7 @@ export class ListsWriteService {
       throw new Error("Failed to insert list entry");
     }
 
-    const currentTypes = await ListsReadRepository.getCurrentItemTypes(listId);
-    const newDerivedType = deriveListType(currentTypes);
+    const newDerivedType = deriveListType([...currentTypes, itemType]);
 
     await ListsWriteRepository.update(listId, { derivedType: newDerivedType });
 

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -210,12 +210,15 @@ export class UsersController {
 
     const viewerUserId = await resolveViewerUserIdFromHeaders(req.headers);
     const publicOnly = viewerUserId !== profile.id;
+    const { limit, offset } = parseProfileListPagination(req.query);
 
     const lists = await ListsService.getUserLists(
       profile.id,
       publicOnly,
       parsed.data.tmdbId,
       parsed.data.itemType,
+      limit,
+      offset,
     );
 
     res.status(200).json(lists);

--- a/apps/api/tests/integration/lists/crud.test.ts
+++ b/apps/api/tests/integration/lists/crud.test.ts
@@ -1,0 +1,173 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import { signUpTestUser } from "../../support/app/auth-flow";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+describe("lists CRUD", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("requires auth to create a list", async () => {
+    const response = await apiRequest(getServer().baseUrl, "/api/lists", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "Unauthed list" }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("creates a list and fetches its detail", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "crud");
+
+    const createResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/lists",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: "My Favorites",
+          description: "A test list",
+          isPublic: true,
+          isRanked: false,
+        }),
+      },
+      jar,
+    );
+    expect(createResponse.status).toBe(201);
+    const created = (await createResponse.json()) as { id: string; title: string };
+    expect(created.title).toBe("My Favorites");
+
+    const detailResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${created.id}`,
+    );
+    expect(detailResponse.status).toBe(200);
+    const detail = (await detailResponse.json()) as {
+      id: string;
+      itemCount: number;
+      items: unknown[];
+    };
+    expect(detail.id).toBe(created.id);
+    expect(detail.itemCount).toBe(0);
+    expect(detail.items).toEqual([]);
+  });
+
+  it("returns 404 for a non-existent list", async () => {
+    const response = await apiRequest(
+      getServer().baseUrl,
+      "/api/lists/00000000-0000-0000-0000-000000000000",
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("rejects update/delete from a non-owner and allows the owner", async () => {
+    const owner = await signUpTestUser(getServer().baseUrl, "own");
+    const intruder = await signUpTestUser(getServer().baseUrl, "intr");
+
+    const createResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/lists",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Owned list" }),
+      },
+      owner.jar,
+    );
+    const created = (await createResponse.json()) as { id: string };
+
+    const forbiddenUpdate = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${created.id}`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Hijacked" }),
+      },
+      intruder.jar,
+    );
+    expect(forbiddenUpdate.status).toBe(403);
+
+    const forbiddenDelete = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${created.id}`,
+      { method: "DELETE" },
+      intruder.jar,
+    );
+    expect(forbiddenDelete.status).toBe(403);
+
+    const ownerUpdate = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${created.id}`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Renamed" }),
+      },
+      owner.jar,
+    );
+    expect(ownerUpdate.status).toBe(200);
+    const updated = (await ownerUpdate.json()) as { title: string };
+    expect(updated.title).toBe("Renamed");
+
+    const ownerDelete = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${created.id}`,
+      { method: "DELETE" },
+      owner.jar,
+    );
+    expect(ownerDelete.status).toBe(200);
+
+    const afterDelete = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${created.id}`,
+    );
+    expect(afterDelete.status).toBe(404);
+  });
+
+  it("returns 404 when updating/deleting a list that doesn't exist", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "ghost");
+    const missingId = "00000000-0000-0000-0000-000000000000";
+
+    const updateResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${missingId}`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Nope" }),
+      },
+      jar,
+    );
+    expect(updateResponse.status).toBe(404);
+
+    const deleteResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${missingId}`,
+      { method: "DELETE" },
+      jar,
+    );
+    expect(deleteResponse.status).toBe(404);
+  });
+});

--- a/apps/api/tests/integration/lists/item-cap.test.ts
+++ b/apps/api/tests/integration/lists/item-cap.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import { signUpTestUser } from "../../support/app/auth-flow";
+import { seedTestMovie } from "../../support/factories/media.factory";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+import { db } from "../../../src/infrastructure/database/db";
+import { listEntries } from "../../../src/modules/lists/lists.entity";
+import { MAX_LIST_ITEMS } from "../../../src/modules/lists/constants/lists.constants";
+
+describe("list item cap", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("rejects adding an item once a list is at MAX_LIST_ITEMS capacity", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "cap");
+
+    const createResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/lists",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Full list" }),
+      },
+      jar,
+    );
+    const list = (await createResponse.json()) as { id: string };
+
+    // Seed straight into the DB rather than the API — filling a list to
+    // MAX_LIST_ITEMS via real requests would itself trip the mutation rate
+    // limiter (60/min) added in the security-hardening work.
+    await db.insert(listEntries).values(
+      Array.from({ length: MAX_LIST_ITEMS }, (_, i) => ({
+        listId: list.id,
+        itemType: "cinema",
+        position: i + 1,
+      })),
+    );
+
+    const movie = await seedTestMovie();
+    const addResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${list.id}/items`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tmdbId: movie.tmdbId, itemType: "cinema" }),
+      },
+      jar,
+    );
+    expect(addResponse.status).toBe(400);
+    const body = (await addResponse.json()) as { error: string };
+    expect(body.error).toContain(String(MAX_LIST_ITEMS));
+  });
+});

--- a/apps/api/tests/integration/lists/items.test.ts
+++ b/apps/api/tests/integration/lists/items.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import { signUpTestUser } from "../../support/app/auth-flow";
+import { seedTestMovie, seedTestSerial } from "../../support/factories/media.factory";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+describe("list items (dual-media)", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  const createList = async (jar: Awaited<ReturnType<typeof signUpTestUser>>["jar"]) => {
+    const response = await apiRequest(
+      getServer().baseUrl,
+      "/api/lists",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Dual media list" }),
+      },
+      jar,
+    );
+    return (await response.json()) as { id: string };
+  };
+
+  it("adds a movie item and derives type 'cinema'", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "mov");
+    const list = await createList(jar);
+    const movie = await seedTestMovie();
+
+    const addResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${list.id}/items`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tmdbId: movie.tmdbId, itemType: "cinema" }),
+      },
+      jar,
+    );
+    expect(addResponse.status).toBe(201);
+    const added = (await addResponse.json()) as { derivedType: string | null };
+    expect(added.derivedType).toBe("cinema");
+
+    const detail = await apiRequest(getServer().baseUrl, `/api/lists/${list.id}`);
+    const body = (await detail.json()) as { itemCount: number; derivedType: string | null };
+    expect(body.itemCount).toBe(1);
+    expect(body.derivedType).toBe("cinema");
+  });
+
+  it("transitions derivedType through cinema -> mixed -> serial as items change", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "mix");
+    const list = await createList(jar);
+    const movie = await seedTestMovie();
+    const serial = await seedTestSerial();
+
+    const addMovie = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${list.id}/items`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tmdbId: movie.tmdbId, itemType: "cinema" }),
+      },
+      jar,
+    );
+    expect(((await addMovie.json()) as { derivedType: string | null }).derivedType).toBe(
+      "cinema",
+    );
+
+    const addSerial = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${list.id}/items`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tmdbId: serial.tmdbId, itemType: "serial" }),
+      },
+      jar,
+    );
+    const addSerialBody = (await addSerial.json()) as {
+      derivedType: string | null;
+      entry: { id: string };
+    };
+    expect(addSerialBody.derivedType).toBe("mixed");
+
+    const removeResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${list.id}/items/${addSerialBody.entry.id}`,
+      { method: "DELETE" },
+      jar,
+    );
+    expect(removeResponse.status).toBe(200);
+    const removeBody = (await removeResponse.json()) as { derivedType: string | null };
+    expect(removeBody.derivedType).toBe("cinema");
+  });
+
+  it("rejects adding/removing items on a list you don't own, and 404s unknown targets", async () => {
+    const owner = await signUpTestUser(getServer().baseUrl, "iown");
+    const intruder = await signUpTestUser(getServer().baseUrl, "iint");
+    const list = await createList(owner.jar);
+    const movie = await seedTestMovie();
+
+    const forbiddenAdd = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${list.id}/items`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tmdbId: movie.tmdbId, itemType: "cinema" }),
+      },
+      intruder.jar,
+    );
+    expect(forbiddenAdd.status).toBe(403);
+
+    const missingListAdd = await apiRequest(
+      getServer().baseUrl,
+      "/api/lists/00000000-0000-0000-0000-000000000000/items",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tmdbId: movie.tmdbId, itemType: "cinema" }),
+      },
+      owner.jar,
+    );
+    expect(missingListAdd.status).toBe(404);
+
+    const missingEntryRemove = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${list.id}/items/00000000-0000-0000-0000-000000000000`,
+      { method: "DELETE" },
+      owner.jar,
+    );
+    expect(missingEntryRemove.status).toBe(404);
+  });
+});

--- a/apps/api/tests/integration/lists/pagination.test.ts
+++ b/apps/api/tests/integration/lists/pagination.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import { signUpTestUser } from "../../support/app/auth-flow";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+describe("GET /api/users/:username/lists pagination", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("bounds the collection with limit/offset instead of returning everything", async () => {
+    const { jar, username } = await signUpTestUser(getServer().baseUrl, "page");
+
+    for (const title of ["List 1", "List 2", "List 3"]) {
+      const response = await apiRequest(
+        getServer().baseUrl,
+        "/api/lists",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ title }),
+        },
+        jar,
+      );
+      expect(response.status).toBe(201);
+    }
+
+    const allResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/users/${username}/lists`,
+      {},
+      jar,
+    );
+    const all = (await allResponse.json()) as unknown[];
+    expect(all.length).toBe(3);
+
+    const firstPage = await apiRequest(
+      getServer().baseUrl,
+      `/api/users/${username}/lists?limit=2`,
+      {},
+      jar,
+    );
+    const firstPageBody = (await firstPage.json()) as unknown[];
+    expect(firstPageBody.length).toBe(2);
+
+    const secondPage = await apiRequest(
+      getServer().baseUrl,
+      `/api/users/${username}/lists?limit=2&offset=2`,
+      {},
+      jar,
+    );
+    const secondPageBody = (await secondPage.json()) as unknown[];
+    expect(secondPageBody.length).toBe(1);
+  });
+
+  it("falls back to the default page size instead of erroring on an out-of-range limit", async () => {
+    const { jar, username } = await signUpTestUser(getServer().baseUrl, "pgmax");
+
+    const createResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/lists",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Only list" }),
+      },
+      jar,
+    );
+    expect(createResponse.status).toBe(201);
+
+    // limit=1000 exceeds ProfileListQuerySchema's max(100) — the shared
+    // parseProfileListPagination helper treats that as invalid and falls
+    // back to the default page size rather than rejecting the request.
+    const response = await apiRequest(
+      getServer().baseUrl,
+      `/api/users/${username}/lists?limit=1000`,
+      {},
+      jar,
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as unknown[];
+    expect(body.length).toBe(1);
+  });
+});

--- a/apps/api/tests/integration/lists/reorder-likes.test.ts
+++ b/apps/api/tests/integration/lists/reorder-likes.test.ts
@@ -1,0 +1,157 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import { signUpTestUser } from "../../support/app/auth-flow";
+import { seedTestMovie } from "../../support/factories/media.factory";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+describe("list reorder + likes", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("reorders items and rejects entries that don't belong to the list", async () => {
+    const owner = await signUpTestUser(getServer().baseUrl, "reord");
+    const listResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/lists",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Reorder me", isRanked: true }),
+      },
+      owner.jar,
+    );
+    const list = (await listResponse.json()) as { id: string };
+
+    const movieA = await seedTestMovie("A");
+    const movieB = await seedTestMovie("B");
+
+    const addEntry = async (tmdbId: number) => {
+      const response = await apiRequest(
+        getServer().baseUrl,
+        `/api/lists/${list.id}/items`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ tmdbId, itemType: "cinema" }),
+        },
+        owner.jar,
+      );
+      const body = (await response.json()) as { entry: { id: string } };
+      return body.entry.id;
+    };
+
+    const entryAId = await addEntry(movieA.tmdbId);
+    const entryBId = await addEntry(movieB.tmdbId);
+
+    const reorderResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${list.id}/reorder`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          items: [
+            { id: entryBId, position: 1 },
+            { id: entryAId, position: 2 },
+          ],
+        }),
+      },
+      owner.jar,
+    );
+    expect(reorderResponse.status).toBe(200);
+
+    const detail = await apiRequest(getServer().baseUrl, `/api/lists/${list.id}`);
+    const detailBody = (await detail.json()) as { items: Array<{ id: string }> };
+    expect(detailBody.items.map((i) => i.id)).toEqual([entryBId, entryAId]);
+
+    const foreignReorder = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${list.id}/reorder`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          items: [{ id: "00000000-0000-0000-0000-000000000000", position: 1 }],
+        }),
+      },
+      owner.jar,
+    );
+    expect(foreignReorder.status).toBe(403);
+  });
+
+  it("likes and unlikes a public list, and rejects liking a private list you don't own", async () => {
+    const owner = await signUpTestUser(getServer().baseUrl, "likeo");
+    const liker = await signUpTestUser(getServer().baseUrl, "liker");
+
+    const publicListResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/lists",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Public list", isPublic: true }),
+      },
+      owner.jar,
+    );
+    const publicList = (await publicListResponse.json()) as { id: string };
+
+    const likeResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${publicList.id}/like`,
+      { method: "POST" },
+      liker.jar,
+    );
+    expect(likeResponse.status).toBe(200);
+    const likeBody = (await likeResponse.json()) as { likeCount: number };
+    expect(likeBody.likeCount).toBe(1);
+
+    const unlikeResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${publicList.id}/like`,
+      { method: "DELETE" },
+      liker.jar,
+    );
+    expect(unlikeResponse.status).toBe(200);
+    const unlikeBody = (await unlikeResponse.json()) as { likeCount: number };
+    expect(unlikeBody.likeCount).toBe(0);
+
+    const privateListResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/lists",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Private list", isPublic: false }),
+      },
+      owner.jar,
+    );
+    const privateList = (await privateListResponse.json()) as { id: string };
+
+    const forbiddenLike = await apiRequest(
+      getServer().baseUrl,
+      `/api/lists/${privateList.id}/like`,
+      { method: "POST" },
+      liker.jar,
+    );
+    expect(forbiddenLike.status).toBe(403);
+  });
+});

--- a/apps/api/tests/support/app/auth-flow.ts
+++ b/apps/api/tests/support/app/auth-flow.ts
@@ -1,0 +1,33 @@
+import { buildAuthCredentials } from "../factories/auth.factory";
+import { createCookieJar, type CookieJar } from "./cookie-jar";
+import { apiRequest } from "./http-client";
+
+export type SignedUpTestUser = {
+  jar: CookieJar;
+  username: string;
+};
+
+export const signUpTestUser = async (
+  baseUrl: string,
+  prefix = "u",
+): Promise<SignedUpTestUser> => {
+  const credentials = buildAuthCredentials(prefix);
+  const jar = createCookieJar();
+
+  const response = await apiRequest(
+    baseUrl,
+    "/api/auth/sign-up/email",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(credentials),
+    },
+    jar,
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to sign up test user: ${response.status}`);
+  }
+
+  return { jar, username: credentials.username };
+};

--- a/apps/api/tests/support/factories/media.factory.ts
+++ b/apps/api/tests/support/factories/media.factory.ts
@@ -1,0 +1,42 @@
+import { randomInt } from "node:crypto";
+import { db } from "../../../src/infrastructure/database/db";
+import { movies } from "../../../src/modules/movies/movies.entity";
+import { tvSeries } from "../../../src/modules/serials/serials.entity";
+
+// MoviesCacheService/SerialsCacheService.findOrCreate() checks the DB by
+// tmdbId before ever hitting the TMDB API — seeding rows directly here lets
+// list-item tests exercise the real add/remove flow without any network
+// call or a live TMDB_ACCESS_TOKEN.
+const randomTmdbId = (): number => randomInt(1_000_000, 999_000_000);
+
+export const seedTestMovie = async (
+  title = "Test Movie",
+): Promise<{ id: number; tmdbId: number }> => {
+  const tmdbId = randomTmdbId();
+  const [row] = await db
+    .insert(movies)
+    .values({ tmdbId, title })
+    .returning({ id: movies.id, tmdbId: movies.tmdbId });
+
+  if (!row) {
+    throw new Error("Failed to seed test movie");
+  }
+
+  return row;
+};
+
+export const seedTestSerial = async (
+  title = "Test Serial",
+): Promise<{ id: number; tmdbId: number }> => {
+  const tmdbId = randomTmdbId();
+  const [row] = await db
+    .insert(tvSeries)
+    .values({ tmdbId, title })
+    .returning({ id: tvSeries.id, tmdbId: tvSeries.tmdbId });
+
+  if (!row) {
+    throw new Error("Failed to seed test serial");
+  }
+
+  return row;
+};


### PR DESCRIPTION
## Summary
Closes #15. The lists feature (dual-media schema, backend CRUD, and the frontend builder with TMDB autocomplete) was already fully implemented on `master` — the issue text was stale. This PR fixes a real bug that surfaced during hardening and closes the concrete gaps that remained:

- **Bug fix**: `PATCH /api/lists/:id/reorder` was broken — the raw `CASE ... THEN <position> END` SQL had no type hint, so Postgres inferred the branch values as `text`, and every reorder request (drag-and-drop in `ListFormPage`) 500'd against the `integer` `position` column. Fixed with an explicit `::integer` cast. Caught by the new test suite.
- **Pagination**: `GET /api/users/:username/lists` was completely unbounded. Reused the existing `parseProfileListPagination`/`ProfileListQuerySchema` helper already used by sibling profile-list endpoints (default 60, max 100) instead of inventing a new scheme. The item-check query mode (used by `AddToListDialog` to render "already in this list" checkmarks) is intentionally left unpaginated since it needs the complete set to render correctly.
- **Item cap**: `addItem` had no ceiling on list size — capped at 500 items to close an unbounded-growth vector.
- **Test coverage**: the lists module had zero tests despite being explicitly called out in the issue. Added 13 integration tests covering CRUD + ownership (403/404), dual-media items with `derivedType` transitions (cinema → mixed → serial), reorder, likes, pagination, and the item cap. Added two shared test helpers (`signUpTestUser`, `seedTestMovie`/`seedTestSerial` — the latter seed the DB directly so tests don't need a live TMDB token or network access).

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint:arch`
- [x] `bun test` (27/27 passing, including the 13 new lists tests)