### PR TITLE
Serials: paginate diary logs and add interaction/diary test coverage

### DIFF
--- a/apps/api/src/modules/serials/dto/serials.dto.ts
+++ b/apps/api/src/modules/serials/dto/serials.dto.ts
@@ -236,6 +236,32 @@ export type UpdateSerialInteractionDto = z.infer<typeof UpdateSerialInteractionS
 export type CreateSerialLogDto = z.infer<typeof CreateSerialLogSchema>;
 export type UpdateSerialLogDto = z.infer<typeof UpdateSerialLogSchema>;
 
+const DEFAULT_LOGS_LIMIT = 50;
+
+export const SerialLogsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+});
+
+export type SerialLogsQuery = z.input<typeof SerialLogsQuerySchema>;
+
+// Always returns a bounded limit/offset (even with no query params) so the
+// serials logs endpoints (a viewer's own diary, and everyone's logs for a
+// given series) never fetch an entire unbounded collection in one request.
+export const normalizeSerialLogsQuery = (
+  input: unknown,
+): { limit: number; offset: number } => {
+  const parsed = SerialLogsQuerySchema.safeParse(input);
+  if (!parsed.success) {
+    return { limit: DEFAULT_LOGS_LIMIT, offset: 0 };
+  }
+
+  return {
+    limit: parsed.data.limit ?? DEFAULT_LOGS_LIMIT,
+    offset: parsed.data.offset ?? 0,
+  };
+};
+
 export const SerialEpisodeParamsSchema = z.object({
   tmdbId: z.string(),
   seasonNumber: z.coerce.number().int().min(0),

--- a/apps/api/src/modules/serials/repositories/serials-interactions.repository.ts
+++ b/apps/api/src/modules/serials/repositories/serials-interactions.repository.ts
@@ -257,8 +257,8 @@ export class SerialsInteractionsRepository {
     return row?.rating !== null && row?.rating !== undefined;
   }
 
-  static async findAllDiaryByUser(userId: string) {
-    return db
+  static async findAllDiaryByUser(userId: string, limit?: number, offset?: number) {
+    const query = db
       .select({
         id: serialDiaryEntries.id,
         watchedDate: serialDiaryEntries.watchedDate,
@@ -287,7 +287,10 @@ export class SerialsInteractionsRepository {
         ),
       )
       .where(eq(serialDiaryEntries.userId, userId))
-      .orderBy(desc(serialDiaryEntries.watchedDate), desc(serialDiaryEntries.createdAt));
+      .orderBy(desc(serialDiaryEntries.watchedDate), desc(serialDiaryEntries.createdAt))
+      .$dynamic();
+
+    return limit ? query.limit(limit).offset(offset ?? 0) : query;
   }
 
   static async updateDiaryEntry(
@@ -317,8 +320,8 @@ export class SerialsInteractionsRepository {
     return deleted ?? null;
   }
 
-  static async getLogsBySeriesId(seriesId: number) {
-    return db
+  static async getLogsBySeriesId(seriesId: number, limit?: number, offset?: number) {
+    const query = db
       .select({
         diaryEntryId: serialDiaryEntries.id,
         watchedDate: serialDiaryEntries.watchedDate,
@@ -344,6 +347,9 @@ export class SerialsInteractionsRepository {
         ),
       )
       .where(eq(serialDiaryEntries.seriesId, seriesId))
-      .orderBy(desc(serialDiaryEntries.createdAt));
+      .orderBy(desc(serialDiaryEntries.createdAt))
+      .$dynamic();
+
+    return limit ? query.limit(limit).offset(offset ?? 0) : query;
   }
 }

--- a/apps/api/src/modules/serials/serials.controller.ts
+++ b/apps/api/src/modules/serials/serials.controller.ts
@@ -17,6 +17,7 @@ import {
   CreateSerialLogSchema,
   normalizeSerialArchiveQuery,
   normalizeSerialDetailQuery,
+  normalizeSerialLogsQuery,
   SearchSerialsQuerySchema,
   SerialSeasonParamsSchema,
   UpdateSerialInteractionSchema,
@@ -229,7 +230,8 @@ export class SerialsController {
       return;
     }
 
-    const logs = await SerialsService.getLogs(tmdbId);
+    const { limit, offset } = normalizeSerialLogsQuery(req.query);
+    const logs = await SerialsService.getLogs(tmdbId, limit, offset);
     if (logs === null) {
       res.status(404).json({ error: "Series not found" });
       return;
@@ -239,7 +241,8 @@ export class SerialsController {
   }
 
   static async getMyLogs(req: Request, res: Response): Promise<void> {
-    const logs = await SerialsService.getMyLogs(req.user.id);
+    const { limit, offset } = normalizeSerialLogsQuery(req.query);
+    const logs = await SerialsService.getMyLogs(req.user.id, limit, offset);
     res.status(200).json(logs);
   }
 

--- a/apps/api/src/modules/serials/serials.service.ts
+++ b/apps/api/src/modules/serials/serials.service.ts
@@ -87,8 +87,8 @@ export class SerialsService {
     return SerialsActivityService.createLog(userId, tmdbId, input);
   }
 
-  static async getMyLogs(userId: string) {
-    return SerialsActivityService.getMyLogs(userId);
+  static async getMyLogs(userId: string, limit?: number, offset?: number) {
+    return SerialsActivityService.getMyLogs(userId, limit, offset);
   }
 
   static async updateLog(entryId: string, userId: string, input: UpdateSerialLogDto) {
@@ -99,10 +99,10 @@ export class SerialsService {
     return SerialsActivityService.deleteLog(entryId, userId);
   }
 
-  static async getLogs(tmdbId: number) {
+  static async getLogs(tmdbId: number, limit?: number, offset?: number) {
     const series = await SerialsCacheService.findOrCreate(tmdbId);
     if (!series) return null;
-    return SerialsActivityService.getLogs(series.id);
+    return SerialsActivityService.getLogs(series.id, limit, offset);
   }
 
   static async getRecent(): Promise<TMDBSearchSeries[]> {

--- a/apps/api/src/modules/serials/services/serials-activity.service.ts
+++ b/apps/api/src/modules/serials/services/serials-activity.service.ts
@@ -249,8 +249,8 @@ export class SerialsActivityService {
     return { entry, series, review };
   }
 
-  static async getMyLogs(userId: string) {
-    return SerialsInteractionsRepository.findAllDiaryByUser(userId);
+  static async getMyLogs(userId: string, limit?: number, offset?: number) {
+    return SerialsInteractionsRepository.findAllDiaryByUser(userId, limit, offset);
   }
 
   static async updateLog(entryId: string, userId: string, input: UpdateSerialLogDto) {
@@ -265,7 +265,7 @@ export class SerialsActivityService {
     return SerialsInteractionsRepository.deleteDiaryEntry(entryId, userId);
   }
 
-  static async getLogs(seriesId: number) {
-    return SerialsInteractionsRepository.getLogsBySeriesId(seriesId);
+  static async getLogs(seriesId: number, limit?: number, offset?: number) {
+    return SerialsInteractionsRepository.getLogsBySeriesId(seriesId, limit, offset);
   }
 }

--- a/apps/api/tests/integration/serials/diary-logs.test.ts
+++ b/apps/api/tests/integration/serials/diary-logs.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import { signUpTestUser } from "../../support/app/auth-flow";
+import { seedTestSerial } from "../../support/factories/media.factory";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+describe("serials diary logs", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("requires auth to create a log", async () => {
+    const serial = await seedTestSerial();
+    const response = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/log`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ watchedDate: "2026-01-01" }),
+      },
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("creates a log with a review and surfaces it in both 'my logs' and the series' logs", async () => {
+    const { jar, username } = await signUpTestUser(getServer().baseUrl, "dlog");
+    const serial = await seedTestSerial("Diary Test Serial");
+
+    const createResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/log`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          watchedDate: "2026-01-01",
+          rating: 7.5,
+          rewatch: false,
+          review: "Pretty good.",
+          containsSpoilers: false,
+        }),
+      },
+      jar,
+    );
+    expect(createResponse.status).toBe(201);
+    const created = (await createResponse.json()) as {
+      entry: { id: string; watchedDate: string; rating: number };
+      series: { tmdbId: number };
+      review: { id: string; content: string } | null;
+    };
+    expect(created.entry.rating).toBe(7.5);
+    expect(created.series.tmdbId).toBe(serial.tmdbId);
+    expect(created.review?.content).toBe("Pretty good.");
+
+    const myLogsResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/serials/logs",
+      {},
+      jar,
+    );
+    expect(myLogsResponse.status).toBe(200);
+    const myLogs = (await myLogsResponse.json()) as Array<{ id: string; seriesTmdbId: number }>;
+    expect(myLogs.some((log) => log.id === created.entry.id)).toBe(true);
+
+    const seriesLogsResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/logs`,
+    );
+    expect(seriesLogsResponse.status).toBe(200);
+    const seriesLogs = (await seriesLogsResponse.json()) as Array<{
+      diaryEntryId: string;
+      username: string;
+    }>;
+    expect(seriesLogs.some((log) => log.diaryEntryId === created.entry.id && log.username === username)).toBe(
+      true,
+    );
+  });
+
+  it("lets the owner update and delete a log, and hides other users' logs from mutation", async () => {
+    const owner = await signUpTestUser(getServer().baseUrl, "dlogo");
+    const intruder = await signUpTestUser(getServer().baseUrl, "dlogi");
+    const serial = await seedTestSerial();
+
+    const createResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/log`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ watchedDate: "2026-01-02", rating: 5 }),
+      },
+      owner.jar,
+    );
+    const created = (await createResponse.json()) as { entry: { id: string } };
+    const entryId = created.entry.id;
+
+    const intruderUpdate = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/logs/${entryId}`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ rating: 1 }),
+      },
+      intruder.jar,
+    );
+    expect(intruderUpdate.status).toBe(404);
+
+    const intruderDelete = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/logs/${entryId}`,
+      { method: "DELETE" },
+      intruder.jar,
+    );
+    expect(intruderDelete.status).toBe(404);
+
+    const ownerUpdate = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/logs/${entryId}`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ rating: 9 }),
+      },
+      owner.jar,
+    );
+    expect(ownerUpdate.status).toBe(200);
+    const updated = (await ownerUpdate.json()) as { rating: number };
+    expect(updated.rating).toBe(9);
+
+    const ownerDelete = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/logs/${entryId}`,
+      { method: "DELETE" },
+      owner.jar,
+    );
+    expect(ownerDelete.status).toBe(200);
+
+    const myLogsAfterDelete = await apiRequest(
+      getServer().baseUrl,
+      "/api/serials/logs",
+      {},
+      owner.jar,
+    );
+    const logsAfterDelete = (await myLogsAfterDelete.json()) as Array<{ id: string }>;
+    expect(logsAfterDelete.some((log) => log.id === entryId)).toBe(false);
+  });
+
+  it("bounds 'my logs' with limit/offset instead of returning everything", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "dlogp");
+
+    for (const day of ["2026-01-01", "2026-01-02", "2026-01-03"]) {
+      const serial = await seedTestSerial();
+      const response = await apiRequest(
+        getServer().baseUrl,
+        `/api/serials/${serial.tmdbId}/log`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ watchedDate: day }),
+        },
+        jar,
+      );
+      expect(response.status).toBe(201);
+    }
+
+    const firstPage = await apiRequest(
+      getServer().baseUrl,
+      "/api/serials/logs?limit=2",
+      {},
+      jar,
+    );
+    const firstPageBody = (await firstPage.json()) as unknown[];
+    expect(firstPageBody.length).toBe(2);
+
+    const secondPage = await apiRequest(
+      getServer().baseUrl,
+      "/api/serials/logs?limit=2&offset=2",
+      {},
+      jar,
+    );
+    const secondPageBody = (await secondPage.json()) as unknown[];
+    expect(secondPageBody.length).toBe(1);
+  });
+});

--- a/apps/api/tests/integration/serials/season-episode-interaction.test.ts
+++ b/apps/api/tests/integration/serials/season-episode-interaction.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import { signUpTestUser } from "../../support/app/auth-flow";
+import { seedTestSerial } from "../../support/factories/media.factory";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+// updateSeasonInteraction/updateEpisodeInteraction best-effort cascade to
+// TMDB-backed episode data (tmdbGetSeasonDetails) whenever the resulting
+// state is "watched" — that call is wrapped in .catch(() => null), so it
+// fails harmlessly against a fake seeded series/tmdbId and the season/
+// episode row's own watched/liked/rating state (what these tests assert on)
+// is persisted and returned correctly regardless.
+describe("season and episode interaction", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("requires auth for season and episode interaction updates", async () => {
+    const serial = await seedTestSerial();
+
+    const seasonResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/interaction`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ liked: true }),
+      },
+    );
+    expect(seasonResponse.status).toBe(401);
+
+    const episodeResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/episodes/1/interaction`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ liked: true }),
+      },
+    );
+    expect(episodeResponse.status).toBe(401);
+  }, 15000);
+
+  it("persists season-level watched/liked/rating", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "seaint");
+    const serial = await seedTestSerial();
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/interaction`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ liked: true, rating: 9 }),
+      },
+      jar,
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      watched: boolean;
+      liked: boolean;
+      rating: number;
+    };
+    expect(body.liked).toBe(true);
+    expect(body.rating).toBe(9);
+    // Rating implicitly marks the season watched, mirroring series-level behavior.
+    expect(body.watched).toBe(true);
+  }, 15000);
+
+  it("persists episode-level watched/liked/rating", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "epint");
+    const serial = await seedTestSerial();
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/episodes/1/interaction`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ watched: true, liked: true }),
+      },
+      jar,
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { watched: boolean; liked: boolean };
+    expect(body.watched).toBe(true);
+    expect(body.liked).toBe(true);
+  }, 15000);
+
+  it("rejects an invalid episode number", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "epbad");
+    const serial = await seedTestSerial();
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/episodes/0/interaction`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ watched: true }),
+      },
+      jar,
+    );
+    expect(response.status).toBe(400);
+  });
+});

--- a/apps/api/tests/integration/serials/season-episode-review.test.ts
+++ b/apps/api/tests/integration/serials/season-episode-review.test.ts
@@ -1,0 +1,136 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import { signUpTestUser } from "../../support/app/auth-flow";
+import { seedTestSerial } from "../../support/factories/media.factory";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+describe("season and episode reviews", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("creates, reads, and deletes a season review", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "seasrev");
+    const serial = await seedTestSerial();
+
+    const missingResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/review`,
+      {},
+      jar,
+    );
+    expect(missingResponse.status).toBe(200);
+    expect(await missingResponse.json()).toBeNull();
+
+    const upsertResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/review`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "Great season.", containsSpoilers: false }),
+      },
+      jar,
+    );
+    expect(upsertResponse.status).toBe(200);
+    const upserted = (await upsertResponse.json()) as { content: string };
+    expect(upserted.content).toBe("Great season.");
+
+    const getResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/review`,
+      {},
+      jar,
+    );
+    const fetched = (await getResponse.json()) as { content: string };
+    expect(fetched.content).toBe("Great season.");
+
+    const deleteResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/review`,
+      { method: "DELETE" },
+      jar,
+    );
+    expect(deleteResponse.status).toBe(200);
+
+    const afterDeleteResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/review`,
+      {},
+      jar,
+    );
+    expect(await afterDeleteResponse.json()).toBeNull();
+  });
+
+  it("creates, reads, and deletes an episode review", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "eprev");
+    const serial = await seedTestSerial();
+
+    const upsertResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/episodes/1/review`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "Great episode.", containsSpoilers: true }),
+      },
+      jar,
+    );
+    expect(upsertResponse.status).toBe(200);
+    const upserted = (await upsertResponse.json()) as {
+      content: string;
+      containsSpoilers: boolean;
+    };
+    expect(upserted.content).toBe("Great episode.");
+    expect(upserted.containsSpoilers).toBe(true);
+
+    const deleteResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/episodes/1/review`,
+      { method: "DELETE" },
+      jar,
+    );
+    expect(deleteResponse.status).toBe(200);
+
+    const missingDeleteResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/episodes/1/review`,
+      { method: "DELETE" },
+      jar,
+    );
+    expect(missingDeleteResponse.status).toBe(404);
+  });
+
+  it("requires auth for season and episode review endpoints", async () => {
+    const serial = await seedTestSerial();
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/seasons/1/review`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "Nope" }),
+      },
+    );
+    expect(response.status).toBe(401);
+  });
+});

--- a/apps/api/tests/integration/serials/series-interaction.test.ts
+++ b/apps/api/tests/integration/serials/series-interaction.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import { signUpTestUser } from "../../support/app/auth-flow";
+import { seedTestSerial } from "../../support/factories/media.factory";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+describe("series-level interaction", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("requires auth to read or write a series interaction", async () => {
+    const serial = await seedTestSerial();
+
+    const getResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/interaction`,
+    );
+    expect(getResponse.status).toBe(401);
+
+    const putResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/interaction`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ liked: true }),
+      },
+    );
+    expect(putResponse.status).toBe(401);
+  });
+
+  it("defaults to all-false/null before any interaction exists", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "sidef");
+    const serial = await seedTestSerial();
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/interaction`,
+      {},
+      jar,
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      liked: boolean;
+      watchlisted: boolean;
+      rating: number | null;
+      watched: boolean;
+    };
+    expect(body).toEqual({
+      liked: false,
+      watchlisted: false,
+      rating: null,
+      watched: false,
+    });
+  });
+
+  it("persists a partial update without clobbering other fields", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "sipar");
+    const serial = await seedTestSerial();
+
+    const likeResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/interaction`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ liked: true }),
+      },
+      jar,
+    );
+    expect(likeResponse.status).toBe(200);
+
+    const watchlistResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/interaction`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ watchlisted: true }),
+      },
+      jar,
+    );
+    expect(watchlistResponse.status).toBe(200);
+    const watchlistBody = (await watchlistResponse.json()) as {
+      liked: boolean;
+      watchlisted: boolean;
+    };
+    // Setting watchlisted must not reset the earlier liked:true.
+    expect(watchlistBody.liked).toBe(true);
+    expect(watchlistBody.watchlisted).toBe(true);
+
+    const getResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/interaction`,
+      {},
+      jar,
+    );
+    const getBody = (await getResponse.json()) as {
+      liked: boolean;
+      watchlisted: boolean;
+    };
+    expect(getBody.liked).toBe(true);
+    expect(getBody.watchlisted).toBe(true);
+  });
+
+  it("rating implicitly marks the series watched", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "siwat");
+    const serial = await seedTestSerial();
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      `/api/serials/${serial.tmdbId}/interaction`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ rating: 8 }),
+      },
+      jar,
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { rating: number; watched: boolean };
+    expect(body.rating).toBe(8);
+    expect(body.watched).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #16. The serials interactions/diary system (series-level like/watchlist/rate/watched, diary log CRUD, season/episode watched/liked/rating tracking with bidirectional cascade sync, and season/episode reviews) was already fully implemented on `master` — the issue text was stale. This PR closes the two concrete gaps that remained:

- **Pagination**: `GET /api/serials/logs` (a viewer's own diary) and `GET /api/serials/:tmdbId/logs` (everyone's logs for a series) were both completely unbounded. Added a local `SerialLogsQuerySchema`/`normalizeSerialLogsQuery` (default 50, max 100), following the same pattern used for lists pagination in #15, threaded through the repository, service, and facade layers.
- **Test coverage**: the serials interactions/diary system had zero tests despite being explicitly requested by the issue. Added 15 integration tests covering series-level interactions (partial updates, implicit-watched-on-rating, ownership via auth), diary log CRUD (create with review, update/delete ownership 404s, pagination), season and episode interaction updates, and season/episode review CRUD.

Season/episode interaction tests seed a fake series (`seedTestSerial`) rather than using a real TMDB id — the best-effort watched-state cascade to `tmdbGetSeasonDetails` fails harmlessly (it's wrapped in `.catch(() => null)` in the service) without needing network access or a live TMDB token for the assertions that matter.

## Noted, not fixed here (cross-cutting, different issue)
`serialInteractions` and `movieInteractions` both lack a standalone index on `seriesId`/`movieId`; the community-rating aggregation query filters by that column alone and can't use the existing composite-unique index efficiently. Affects both modules equally — belongs to issue #18 (Performance: Database Indexes), not this one.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint:arch`
- [x] `bun test` (42/42 passing, including the 15 new serials tests)