### PR TITLE
Performance: composite indexes, TMDB cache TTL, query parallelization, feed cache, and frontend memoization

### DIFF
--- a/apps/api/drizzle/0038_good_molten_man.sql
+++ b/apps/api/drizzle/0038_good_molten_man.sql
@@ -1,0 +1,8 @@
+CREATE INDEX "serial_diary_entry_user_watched_created_idx" ON "serial_diary_entry" USING btree ("user_id","watched_date","created_at");--> statement-breakpoint
+CREATE INDEX "serial_diary_entry_series_rating_idx" ON "serial_diary_entry" USING btree ("series_id","rating") WHERE rating is not null;--> statement-breakpoint
+CREATE INDEX "serial_interaction_series_rating_idx" ON "serial_interaction" USING btree ("series_id","rating") WHERE rating is not null;--> statement-breakpoint
+CREATE INDEX "diary_entry_user_watched_created_idx" ON "diary_entry" USING btree ("user_id","watched_date","created_at");--> statement-breakpoint
+CREATE INDEX "diary_entry_movie_rating_idx" ON "diary_entry" USING btree ("movie_id","rating") WHERE rating is not null;--> statement-breakpoint
+CREATE INDEX "movie_interaction_movie_rating_idx" ON "movie_interaction" USING btree ("movie_id","rating") WHERE rating is not null;--> statement-breakpoint
+CREATE INDEX "post_user_created_idx" ON "post" USING btree ("user_id","created_at");--> statement-breakpoint
+CREATE INDEX "list_user_updated_idx" ON "list" USING btree ("user_id","updated_at");

--- a/apps/api/drizzle/meta/0038_snapshot.json
+++ b/apps/api/drizzle/meta/0038_snapshot.json
@@ -1,0 +1,3060 @@
+{
+  "id": "f875b2af-ab16-4e58-a765-011980d384e2",
+  "prevId": "1ccda920-c5ef-4eb3-b5f0-6fbb9ba9bc23",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movie": {
+      "name": "movie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "director": {
+          "name": "director",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movie_tmdb_id_unique": {
+          "name": "movie_tmdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_diary_entry": {
+      "name": "serial_diary_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched_date": {
+          "name": "watched_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewatch": {
+          "name": "rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "serial_diary_entry_user_id_idx": {
+          "name": "serial_diary_entry_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serial_diary_entry_series_id_idx": {
+          "name": "serial_diary_entry_series_id_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serial_diary_entry_user_watched_created_idx": {
+          "name": "serial_diary_entry_user_watched_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "watched_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serial_diary_entry_series_rating_idx": {
+          "name": "serial_diary_entry_series_rating_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "serial_diary_entry_user_id_user_id_fk": {
+          "name": "serial_diary_entry_user_id_user_id_fk",
+          "tableFrom": "serial_diary_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_diary_entry_series_id_tv_series_id_fk": {
+          "name": "serial_diary_entry_series_id_tv_series_id_fk",
+          "tableFrom": "serial_diary_entry",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_episode_interaction": {
+      "name": "serial_episode_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched": {
+          "name": "watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "serial_episode_interaction_user_id_user_id_fk": {
+          "name": "serial_episode_interaction_user_id_user_id_fk",
+          "tableFrom": "serial_episode_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_episode_interaction_series_id_tv_series_id_fk": {
+          "name": "serial_episode_interaction_series_id_tv_series_id_fk",
+          "tableFrom": "serial_episode_interaction",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "serial_episode_interactions_unique": {
+          "name": "serial_episode_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series_id",
+            "season_number",
+            "episode_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_interaction": {
+      "name": "serial_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "watchlisted": {
+          "name": "watchlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_watched": {
+          "name": "is_watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "serial_interaction_series_rating_idx": {
+          "name": "serial_interaction_series_rating_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "serial_interaction_user_id_user_id_fk": {
+          "name": "serial_interaction_user_id_user_id_fk",
+          "tableFrom": "serial_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_interaction_series_id_tv_series_id_fk": {
+          "name": "serial_interaction_series_id_tv_series_id_fk",
+          "tableFrom": "serial_interaction",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "serial_interactions_unique": {
+          "name": "serial_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_season_interaction": {
+      "name": "serial_season_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched": {
+          "name": "watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "serial_season_interaction_user_id_user_id_fk": {
+          "name": "serial_season_interaction_user_id_user_id_fk",
+          "tableFrom": "serial_season_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_season_interaction_series_id_tv_series_id_fk": {
+          "name": "serial_season_interaction_series_id_tv_series_id_fk",
+          "tableFrom": "serial_season_interaction",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "serial_season_interactions_unique": {
+          "name": "serial_season_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series_id",
+            "season_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tv_series": {
+      "name": "tv_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_air_date": {
+          "name": "first_air_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_air_year": {
+          "name": "first_air_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_air_date": {
+          "name": "last_air_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "episode_runtime": {
+          "name": "episode_runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_seasons": {
+          "name": "number_of_seasons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_episodes": {
+          "name": "number_of_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tv_series_tmdb_id_unique": {
+          "name": "tv_series_tmdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person": {
+      "name": "person",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_person_id": {
+          "name": "tmdb_person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "known_for_department": {
+          "name": "known_for_department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_role_hints": {
+          "name": "route_role_hints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "profile_path": {
+          "name": "profile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_tmdb_person_id_unique": {
+          "name": "person_tmdb_person_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_person_id"
+          ]
+        },
+        "person_slug_unique": {
+          "name": "person_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_slug_alias": {
+      "name": "person_slug_alias",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_slug_alias_person_id_idx": {
+          "name": "person_slug_alias_person_id_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_slug_alias_person_id_person_id_fk": {
+          "name": "person_slug_alias_person_id_person_id_fk",
+          "tableFrom": "person_slug_alias",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_slug_alias_slug_unique": {
+          "name": "person_slug_alias_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_top_pick": {
+      "name": "profile_top_pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_source": {
+          "name": "media_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tmdb'"
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_top_pick_user_id_user_id_fk": {
+          "name": "profile_top_pick_user_id_user_id_fk",
+          "tableFrom": "profile_top_pick",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_top_pick_user_category_slot_unique": {
+          "name": "profile_top_pick_user_category_slot_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "category_id",
+            "slot"
+          ]
+        },
+        "profile_top_pick_user_category_media_unique": {
+          "name": "profile_top_pick_user_category_media_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "category_id",
+            "media_source",
+            "media_source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_genres": {
+          "name": "favorite_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rose-pine'"
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_user_id_user_id_fk": {
+          "name": "profile_user_id_user_id_fk",
+          "tableFrom": "profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diary_entry": {
+      "name": "diary_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched_date": {
+          "name": "watched_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewatch": {
+          "name": "rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diary_entry_user_id_idx": {
+          "name": "diary_entry_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entry_movie_id_idx": {
+          "name": "diary_entry_movie_id_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entry_user_watched_created_idx": {
+          "name": "diary_entry_user_watched_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "watched_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entry_movie_rating_idx": {
+          "name": "diary_entry_movie_rating_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "diary_entry_user_id_user_id_fk": {
+          "name": "diary_entry_user_id_user_id_fk",
+          "tableFrom": "diary_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "diary_entry_movie_id_movie_id_fk": {
+          "name": "diary_entry_movie_id_movie_id_fk",
+          "tableFrom": "diary_entry",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_like": {
+      "name": "comment_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comment_like_user_id_user_id_fk": {
+          "name": "comment_like_user_id_user_id_fk",
+          "tableFrom": "comment_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_like_comment_id_comment_id_fk": {
+          "name": "comment_like_comment_id_comment_id_fk",
+          "tableFrom": "comment_like",
+          "tableTo": "comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comment_likes_unique": {
+          "name": "comment_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "comment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_review_id_idx": {
+          "name": "comment_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_user_id_user_id_fk": {
+          "name": "comment_user_id_user_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_review_id_review_id_fk": {
+          "name": "comment_review_id_review_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "review",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_like": {
+      "name": "review_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_like_user_id_user_id_fk": {
+          "name": "review_like_user_id_user_id_fk",
+          "tableFrom": "review_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_like_review_id_review_id_fk": {
+          "name": "review_like_review_id_review_id_fk",
+          "tableFrom": "review_like",
+          "tableTo": "review",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "review_likes_unique": {
+          "name": "review_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "review_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'movie'"
+        },
+        "media_source": {
+          "name": "media_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tmdb'"
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diary_entry_id": {
+          "name": "diary_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contains_spoilers": {
+          "name": "contains_spoilers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_movie_id_idx": {
+          "name": "review_movie_id_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_diary_entry_id_idx": {
+          "name": "review_diary_entry_id_idx",
+          "columns": [
+            {
+              "expression": "diary_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_user_id_user_id_fk": {
+          "name": "review_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_movie_id_movie_id_fk": {
+          "name": "review_movie_id_movie_id_fk",
+          "tableFrom": "review",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_user_media_unique": {
+          "name": "reviews_user_media_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "media_type",
+            "media_source",
+            "media_source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movie_interaction": {
+      "name": "movie_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "watchlisted": {
+          "name": "watchlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_watched": {
+          "name": "is_watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "movie_interaction_movie_rating_idx": {
+          "name": "movie_interaction_movie_rating_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "movie_interaction_user_id_user_id_fk": {
+          "name": "movie_interaction_user_id_user_id_fk",
+          "tableFrom": "movie_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "movie_interaction_movie_id_movie_id_fk": {
+          "name": "movie_interaction_movie_id_movie_id_fk",
+          "tableFrom": "movie_interaction",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movie_interactions_unique": {
+          "name": "movie_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "movie_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_comment": {
+      "name": "post_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_comment_post_id_idx": {
+          "name": "post_comment_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_comment_user_id_user_id_fk": {
+          "name": "post_comment_user_id_user_id_fk",
+          "tableFrom": "post_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comment_post_id_post_id_fk": {
+          "name": "post_comment_post_id_post_id_fk",
+          "tableFrom": "post_comment",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_like": {
+      "name": "post_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_like_user_id_user_id_fk": {
+          "name": "post_like_user_id_user_id_fk",
+          "tableFrom": "post_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_like_post_id_post_id_fk": {
+          "name": "post_like_post_id_post_id_fk",
+          "tableFrom": "post_like",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_likes_unique": {
+          "name": "post_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post": {
+      "name": "post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "post_media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_user_id_idx": {
+          "name": "post_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_media_id_idx": {
+          "name": "post_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_user_created_idx": {
+          "name": "post_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_user_id_user_id_fk": {
+          "name": "post_user_id_user_id_fk",
+          "tableFrom": "post",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_user_id_created_at_idx": {
+          "name": "activity_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_user_id_user_id_fk": {
+          "name": "activity_user_id_user_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_like": {
+      "name": "activity_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_like_user_id_user_id_fk": {
+          "name": "activity_like_user_id_user_id_fk",
+          "tableFrom": "activity_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_like_activity_id_activity_id_fk": {
+          "name": "activity_like_activity_id_activity_id_fk",
+          "tableFrom": "activity_like",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "activity_likes_unique": {
+          "name": "activity_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "activity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follow": {
+      "name": "follow",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follows_following_id_idx": {
+          "name": "follows_following_id_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_follower_id_user_id_fk": {
+          "name": "follow_follower_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follow_following_id_user_id_fk": {
+          "name": "follow_following_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follows_unique": {
+          "name": "follows_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_entry": {
+      "name": "list_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tv_series_id": {
+          "name": "tv_series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "le_cinema_unique": {
+          "name": "le_cinema_unique",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "movie_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "le_serial_unique": {
+          "name": "le_serial_unique",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tv_series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "tv_series_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "list_entry_list_id_list_id_fk": {
+          "name": "list_entry_list_id_list_id_fk",
+          "tableFrom": "list_entry",
+          "tableTo": "list",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_entry_movie_id_movie_id_fk": {
+          "name": "list_entry_movie_id_movie_id_fk",
+          "tableFrom": "list_entry",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_entry_tv_series_id_tv_series_id_fk": {
+          "name": "list_entry_tv_series_id_tv_series_id_fk",
+          "tableFrom": "list_entry",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "tv_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_like": {
+      "name": "list_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_like_user_id_user_id_fk": {
+          "name": "list_like_user_id_user_id_fk",
+          "tableFrom": "list_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_like_list_id_list_id_fk": {
+          "name": "list_like_list_id_list_id_fk",
+          "tableFrom": "list_like",
+          "tableTo": "list",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "list_likes_unique": {
+          "name": "list_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "list_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list": {
+      "name": "list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ranked": {
+          "name": "is_ranked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "derived_type": {
+          "name": "derived_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_user_id_idx": {
+          "name": "list_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_user_updated_idx": {
+          "name": "list_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "list_user_id_user_id_fk": {
+          "name": "list_user_id_user_id_fk",
+          "tableFrom": "list",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.post_media_type": {
+      "name": "post_media_type",
+      "schema": "public",
+      "values": [
+        "movie",
+        "tv"
+      ]
+    },
+    "public.activity_type": {
+      "name": "activity_type",
+      "schema": "public",
+      "values": [
+        "diary_entry",
+        "review",
+        "liked_movie",
+        "watchlisted_movie",
+        "followed_user",
+        "created_list",
+        "liked_review",
+        "commented",
+        "post"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1783811234688,
       "tag": "0037_bitter_photon",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1784228270155,
+      "tag": "0038_good_molten_man",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/infrastructure/cache/ttl-cache.helper.ts
+++ b/apps/api/src/infrastructure/cache/ttl-cache.helper.ts
@@ -1,0 +1,82 @@
+const DEFAULT_TTL_MS = 30 * 60 * 1000;
+const DEFAULT_MAX_ENTRIES = 1_000;
+
+/**
+ * TTL cache + in-flight de-dupe keyed by the fetcher's arguments (or a
+ * composite key derived via `keyFn`, for lookups that take more than one
+ * argument), for read-mostly data that would otherwise be recomputed on
+ * every request touching it.
+ */
+export const createTtlCache = <Args extends unknown[], T>(
+  fetcher: (...args: Args) => Promise<T>,
+  options: {
+    keyFn?: (...args: Args) => string | number;
+    ttlMs?: number;
+    maxEntries?: number;
+  } = {},
+): ((...args: Args) => Promise<T>) => {
+  const keyFn = options.keyFn ?? ((...args: Args) => args.join(":"));
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+
+  const cache = new Map<string | number, { value: T; expiresAt: number }>();
+  const inFlight = new Map<string | number, Promise<T>>();
+
+  const prune = (now: number): void => {
+    for (const [cachedKey, cacheEntry] of cache) {
+      if (cacheEntry.expiresAt <= now) {
+        cache.delete(cachedKey);
+      }
+    }
+
+    if (cache.size <= maxEntries) {
+      return;
+    }
+
+    const overflow = cache.size - maxEntries;
+    const cacheKeys = cache.keys();
+
+    for (let index = 0; index < overflow; index += 1) {
+      const nextKey = cacheKeys.next();
+      if (nextKey.done) {
+        break;
+      }
+
+      cache.delete(nextKey.value);
+    }
+  };
+
+  return async (...args: Args): Promise<T> => {
+    const key = keyFn(...args);
+    const now = Date.now();
+    const cached = cache.get(key);
+
+    if (cached && cached.expiresAt > now) {
+      return cached.value;
+    }
+
+    if (cached) {
+      cache.delete(key);
+    }
+
+    const inFlightRequest = inFlight.get(key);
+    if (inFlightRequest) {
+      return inFlightRequest;
+    }
+
+    const requestPromise = (async () => {
+      const value = await fetcher(...args);
+      cache.set(key, { value, expiresAt: Date.now() + ttlMs });
+      prune(Date.now());
+      return value;
+    })();
+
+    inFlight.set(key, requestPromise);
+
+    try {
+      return await requestPromise;
+    } finally {
+      inFlight.delete(key);
+    }
+  };
+};

--- a/apps/api/src/infrastructure/tmdb/tmdb-cache.helper.ts
+++ b/apps/api/src/infrastructure/tmdb/tmdb-cache.helper.ts
@@ -1,3 +1,5 @@
+import { createTtlCache } from "../cache/ttl-cache.helper";
+
 const TMDB_ENTITY_CACHE_TTL_MS = 30 * 60 * 1000;
 const TMDB_ENTITY_CACHE_MAX_ENTRIES = 1_000;
 
@@ -16,69 +18,9 @@ export const createCachedTmdbFetcher = <Args extends unknown[], T>(
     ttlMs?: number;
     maxEntries?: number;
   } = {},
-): ((...args: Args) => Promise<T>) => {
-  const keyFn = options.keyFn ?? ((...args: Args) => args.join(":"));
-  const ttlMs = options.ttlMs ?? TMDB_ENTITY_CACHE_TTL_MS;
-  const maxEntries = options.maxEntries ?? TMDB_ENTITY_CACHE_MAX_ENTRIES;
-
-  const cache = new Map<string | number, { value: T; expiresAt: number }>();
-  const inFlight = new Map<string | number, Promise<T>>();
-
-  const prune = (now: number): void => {
-    for (const [cachedKey, cacheEntry] of cache) {
-      if (cacheEntry.expiresAt <= now) {
-        cache.delete(cachedKey);
-      }
-    }
-
-    if (cache.size <= maxEntries) {
-      return;
-    }
-
-    const overflow = cache.size - maxEntries;
-    const cacheKeys = cache.keys();
-
-    for (let index = 0; index < overflow; index += 1) {
-      const nextKey = cacheKeys.next();
-      if (nextKey.done) {
-        break;
-      }
-
-      cache.delete(nextKey.value);
-    }
-  };
-
-  return async (...args: Args): Promise<T> => {
-    const key = keyFn(...args);
-    const now = Date.now();
-    const cached = cache.get(key);
-
-    if (cached && cached.expiresAt > now) {
-      return cached.value;
-    }
-
-    if (cached) {
-      cache.delete(key);
-    }
-
-    const inFlightRequest = inFlight.get(key);
-    if (inFlightRequest) {
-      return inFlightRequest;
-    }
-
-    const requestPromise = (async () => {
-      const value = await fetcher(...args);
-      cache.set(key, { value, expiresAt: Date.now() + ttlMs });
-      prune(Date.now());
-      return value;
-    })();
-
-    inFlight.set(key, requestPromise);
-
-    try {
-      return await requestPromise;
-    } finally {
-      inFlight.delete(key);
-    }
-  };
-};
+): ((...args: Args) => Promise<T>) =>
+  createTtlCache(fetcher, {
+    ttlMs: TMDB_ENTITY_CACHE_TTL_MS,
+    maxEntries: TMDB_ENTITY_CACHE_MAX_ENTRIES,
+    ...options,
+  });

--- a/apps/api/src/modules/diary/diary.entity.ts
+++ b/apps/api/src/modules/diary/diary.entity.ts
@@ -9,6 +9,7 @@ import {
   real,
   index,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { user } from "../../infrastructure/database/auth.entity";
 import { movies } from "../movies/movies.entity";
 
@@ -37,5 +38,15 @@ export const diaryEntries = pgTable(
   (table) => [
     index("diary_entry_user_id_idx").on(table.userId),
     index("diary_entry_movie_id_idx").on(table.movieId),
+    // Backs the diary page query: WHERE user_id = X ORDER BY watched_date DESC, created_at DESC
+    index("diary_entry_user_watched_created_idx").on(
+      table.userId,
+      table.watchedDate,
+      table.createdAt,
+    ),
+    // Backs the community-rating avg() subquery: WHERE movie_id = X AND rating IS NOT NULL
+    index("diary_entry_movie_rating_idx")
+      .on(table.movieId, table.rating)
+      .where(sql`rating is not null`),
   ],
 );

--- a/apps/api/src/modules/diary/services/diary-write.service.ts
+++ b/apps/api/src/modules/diary/services/diary-write.service.ts
@@ -46,28 +46,29 @@ export class DiaryWriteService {
       });
     }
 
-    await InteractionsService.setWatched(userId, movie.id);
-
-    await DiaryRepository.insertActivity({
-      userId,
-      type: "diary_entry",
-      entityId: entry.id,
-      metadata: JSON.stringify(
-        buildDiaryEntryActivityMetadata({
-          movie: {
-            id: movie.id,
-            tmdbId: movie.tmdbId,
-            title: movie.title,
-            posterPath: movie.posterPath,
-            releaseYear: movie.releaseYear,
-          },
-          rating,
-          rewatch,
-          hasReview: Boolean(review),
-          reviewId: review?.id ?? null,
-        }),
-      ),
-    });
+    await Promise.all([
+      InteractionsService.setWatched(userId, movie.id),
+      DiaryRepository.insertActivity({
+        userId,
+        type: "diary_entry",
+        entityId: entry.id,
+        metadata: JSON.stringify(
+          buildDiaryEntryActivityMetadata({
+            movie: {
+              id: movie.id,
+              tmdbId: movie.tmdbId,
+              title: movie.title,
+              posterPath: movie.posterPath,
+              releaseYear: movie.releaseYear,
+            },
+            rating,
+            rewatch,
+            hasReview: Boolean(review),
+            reviewId: review?.id ?? null,
+          }),
+        ),
+      }),
+    ]);
 
     return { entry, movie, review };
   }

--- a/apps/api/src/modules/interactions/interactions.entity.ts
+++ b/apps/api/src/modules/interactions/interactions.entity.ts
@@ -6,7 +6,9 @@ import {
   timestamp,
   unique,
   real,
+  index,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { user } from "../../infrastructure/database/auth.entity";
 import { movies } from "../movies/movies.entity";
 
@@ -30,5 +32,10 @@ export const movieInteractions = pgTable(
   },
   (table) => [
     unique("movie_interactions_unique").on(table.userId, table.movieId),
+    // Backs the community-rating avg() subquery: WHERE movie_id = X AND rating IS NOT NULL
+    // (movieId isn't the leftmost column in the unique index above, so it needs its own)
+    index("movie_interaction_movie_rating_idx")
+      .on(table.movieId, table.rating)
+      .where(sql`rating is not null`),
   ],
 );

--- a/apps/api/src/modules/lists/lists.entity.ts
+++ b/apps/api/src/modules/lists/lists.entity.ts
@@ -33,6 +33,8 @@ export const lists = pgTable("list", {
     .notNull(),
 }, (table) => [
   index("list_user_id_idx").on(table.userId),
+  // Backs the profile lists page query: WHERE user_id = X ORDER BY updated_at DESC
+  index("list_user_updated_idx").on(table.userId, table.updatedAt),
 ]);
 
 export const listEntries = pgTable(

--- a/apps/api/src/modules/lists/services/lists-write.service.ts
+++ b/apps/api/src/modules/lists/services/lists-write.service.ts
@@ -104,15 +104,19 @@ export class ListsWriteService {
     let movieId: number | undefined;
     let tvSeriesId: number | undefined;
 
+    const [media, maxPosition] = await Promise.all([
+      itemType === "cinema"
+        ? MoviesCacheService.findOrCreate(tmdbId)
+        : SerialsCacheService.findOrCreate(tmdbId),
+      ListsReadRepository.getMaxPosition(listId),
+    ]);
+
     if (itemType === "cinema") {
-      const movie = await MoviesCacheService.findOrCreate(tmdbId);
-      movieId = movie.id;
+      movieId = media.id;
     } else {
-      const serial = await SerialsCacheService.findOrCreate(tmdbId);
-      tvSeriesId = serial.id;
+      tvSeriesId = media.id;
     }
 
-    const maxPosition = await ListsReadRepository.getMaxPosition(listId);
     const position = maxPosition + 1;
 
     const entry = await ListsWriteRepository.insertEntry({
@@ -139,13 +143,14 @@ export class ListsWriteService {
     userId: string,
     entryId: string,
   ): Promise<{ success: true; derivedType: string | null } | ServiceError> {
-    const entry = await ListsReadRepository.findEntryById(entryId);
+    const [entry, list] = await Promise.all([
+      ListsReadRepository.findEntryById(entryId),
+      ListsReadRepository.findById(listId),
+    ]);
 
     if (!entry) {
       return { error: "Entry not found", status: 404 };
     }
-
-    const list = await ListsReadRepository.findById(listId);
 
     if (!list) {
       return { error: "List not found", status: 404 };

--- a/apps/api/src/modules/movies/services/movies-cache.service.ts
+++ b/apps/api/src/modules/movies/services/movies-cache.service.ts
@@ -5,21 +5,34 @@ import {
 } from "../../../infrastructure/tmdb/cinemas";
 import { MoviesRepository } from "../repositories/movies.repository";
 
+// Released movies rarely change on TMDB (unlike still-airing series), so a
+// long TTL is fine here — this mainly guards against permanently stale
+// poster/overview edits rather than fast-moving data like episode counts.
+const MOVIE_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+const isStale = (cachedAt: Date): boolean => {
+  return Date.now() - cachedAt.getTime() > MOVIE_CACHE_TTL_MS;
+};
+
 export class MoviesCacheService {
   static async findOrCreate(tmdbId: number) {
     const existing = await MoviesRepository.findByTmdbId(tmdbId);
+    if (existing && !isStale(existing.cachedAt)) {
+      return existing;
+    }
+
+    const tmdbData = await tmdbGetDetails(tmdbId).catch(() => null);
+    const cachedMovie = tmdbData ? await MoviesCacheService.cacheMovie(tmdbData) : null;
+
+    if (cachedMovie) {
+      return cachedMovie;
+    }
+
     if (existing) {
       return existing;
     }
 
-    const tmdbData = await tmdbGetDetails(tmdbId);
-    const cachedMovie = await MoviesCacheService.cacheMovie(tmdbData);
-
-    if (!cachedMovie) {
-      throw new Error(`Failed to cache movie for tmdbId=${tmdbId}`);
-    }
-
-    return cachedMovie;
+    throw new Error(`Failed to cache movie for tmdbId=${tmdbId}`);
   }
 
   static async cacheMovie(tmdbData: TMDBMovieDetail) {

--- a/apps/api/src/modules/posts/posts.entity.ts
+++ b/apps/api/src/modules/posts/posts.entity.ts
@@ -34,6 +34,8 @@ export const posts = pgTable("post", {
 }, (table) => [
   index("post_user_id_idx").on(table.userId),
   index("post_media_id_idx").on(table.mediaId),
+  // Backs the profile posts page query: WHERE user_id = X ORDER BY created_at DESC
+  index("post_user_created_idx").on(table.userId, table.createdAt),
 ]);
 
 export const postLikes = pgTable(

--- a/apps/api/src/modules/reviews/services/reviews-comments.service.ts
+++ b/apps/api/src/modules/reviews/services/reviews-comments.service.ts
@@ -29,30 +29,31 @@ export class ReviewsCommentsService {
         ? review.mediaType
         : null;
 
-    await db.insert(activities).values({
-      userId,
-      type: "commented",
-      entityId: comment.id,
-      metadata: JSON.stringify(
-        buildCommentCreatedActivityMetadata({
-          reviewId,
-          commentId: comment.id,
-          content,
-          targetUsername: review.reviewAuthorUsername,
-          mediaMetadata: activityMediaType
-            ? {
-                mediaType: activityMediaType,
-                tmdbId: review.tmdbId,
-                title: review.title,
-                posterPath: review.posterPath,
-                releaseYear: review.releaseYear,
-              }
-            : null,
-        }),
-      ),
-    });
-
-    const commentWithAuthor = await ReviewsRepository.getCommentWithAuthorById(comment.id);
+    const [, commentWithAuthor] = await Promise.all([
+      db.insert(activities).values({
+        userId,
+        type: "commented",
+        entityId: comment.id,
+        metadata: JSON.stringify(
+          buildCommentCreatedActivityMetadata({
+            reviewId,
+            commentId: comment.id,
+            content,
+            targetUsername: review.reviewAuthorUsername,
+            mediaMetadata: activityMediaType
+              ? {
+                  mediaType: activityMediaType,
+                  tmdbId: review.tmdbId,
+                  title: review.title,
+                  posterPath: review.posterPath,
+                  releaseYear: review.releaseYear,
+                }
+              : null,
+          }),
+        ),
+      }),
+      ReviewsRepository.getCommentWithAuthorById(comment.id),
+    ]);
 
     if (!commentWithAuthor) {
       throw new Error("Could not load comment author details");

--- a/apps/api/src/modules/serials/serials.entity.ts
+++ b/apps/api/src/modules/serials/serials.entity.ts
@@ -12,6 +12,7 @@ import {
   uuid,
   real,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { user } from "../../infrastructure/database/auth.entity";
 
 export const tvSeries = pgTable("tv_series", {
@@ -58,6 +59,16 @@ export const serialDiaryEntries = pgTable("serial_diary_entry", {
 }, (table) => [
   index("serial_diary_entry_user_id_idx").on(table.userId),
   index("serial_diary_entry_series_id_idx").on(table.seriesId),
+  // Backs the diary page query: WHERE user_id = X ORDER BY watched_date DESC, created_at DESC
+  index("serial_diary_entry_user_watched_created_idx").on(
+    table.userId,
+    table.watchedDate,
+    table.createdAt,
+  ),
+  // Backs the community-rating avg() subquery: WHERE series_id = X AND rating IS NOT NULL
+  index("serial_diary_entry_series_rating_idx")
+    .on(table.seriesId, table.rating)
+    .where(sql`rating is not null`),
 ]);
 
 export const serialInteractions = pgTable(
@@ -78,7 +89,13 @@ export const serialInteractions = pgTable(
       .$onUpdate(() => new Date())
       .notNull(),
   },
-  (table) => [unique("serial_interactions_unique").on(table.userId, table.seriesId)],
+  (table) => [
+    unique("serial_interactions_unique").on(table.userId, table.seriesId),
+    // Backs the community-rating avg() subquery: WHERE series_id = X AND rating IS NOT NULL
+    index("serial_interaction_series_rating_idx")
+      .on(table.seriesId, table.rating)
+      .where(sql`rating is not null`),
+  ],
 );
 
 export const serialSeasonInteractions = pgTable(

--- a/apps/api/src/modules/social/services/social-feed.service.ts
+++ b/apps/api/src/modules/social/services/social-feed.service.ts
@@ -1,3 +1,4 @@
+import { createTtlCache } from "../../../infrastructure/cache/ttl-cache.helper";
 import { normalizeLimit } from "../helpers/social-feed-metadata.helper";
 import {
   buildActivityEngagementContext,
@@ -16,29 +17,86 @@ export type FeedPage = {
   nextCursor: string | null;
 };
 
+// Feed rows/engagement counts change quickly, so the TTL stays short — this
+// only exists to absorb request bursts (e.g. React Query refetch-on-focus,
+// or two viewers with overlapping follow sets hitting the same page),
+// not to serve meaningfully stale data.
+const FEED_CACHE_TTL_MS = 20 * 1000;
+
+const buildFeedItems = async (
+  rows: ActivityRow[],
+  viewerId?: string,
+): Promise<FeedItem[]> => {
+  const [reviewContext, postEngagementByPostId, activityEngagementById] = await Promise.all([
+    buildReviewContext(rows, viewerId),
+    buildPostEngagementContext(rows, viewerId),
+    buildActivityEngagementContext(rows, viewerId),
+  ]);
+
+  // Depends on reviewContext (a row only needs a movie fallback lookup
+  // when it has no review-attached movie already), so it can't join the
+  // Promise.all above.
+  const fallbackMedia = await buildFeedFallbackMediaContext(rows, reviewContext);
+
+  const feedItems = rows.map((row) =>
+    toFeedItem(row, reviewContext, postEngagementByPostId, activityEngagementById, fallbackMedia),
+  );
+
+  return dedupeReviewFeedItems(feedItems);
+};
+
+const getFollowingFeedUncached = async (
+  userId: string,
+  limit?: number,
+  cursor?: string,
+): Promise<FeedPage> => {
+  const normalizedLimit = normalizeLimit(limit);
+  const fetchLimit = normalizedLimit * 2;
+  const decodedCursor = decodeFeedCursor(cursor);
+
+  const followingRows = await SocialRepository.getFollowingIdsByFollowerId(userId);
+  const feedUserIds = [...new Set([userId, ...followingRows.map((row) => row.followingId)])];
+
+  const rows = await SocialRepository.getFeedActivityRows(feedUserIds, fetchLimit, decodedCursor);
+  const items = await buildFeedItems(rows, userId);
+
+  // Raw rows (pre-dedupe) filling the fetch cap means there may be more
+  // beyond this page; otherwise we've reached the end of the feed.
+  const hasMore = rows.length === fetchLimit;
+  const lastRow = rows.at(-1);
+  const nextCursor =
+    hasMore && lastRow
+      ? encodeFeedCursor({ createdAt: lastRow.activity.createdAt, id: lastRow.activity.id })
+      : null;
+
+  return { items, nextCursor };
+};
+
+const cachedGetFollowingFeed = createTtlCache(getFollowingFeedUncached, {
+  ttlMs: FEED_CACHE_TTL_MS,
+  keyFn: (userId: string, limit?: number, cursor?: string) =>
+    `${userId}:${limit ?? ""}:${cursor ?? ""}`,
+});
+
+const getUserActivityFeedUncached = async (
+  userId: string,
+  limit?: number,
+): Promise<FeedItem[]> => {
+  const normalizedLimit = normalizeLimit(limit);
+  const fetchLimit = normalizedLimit * 2;
+
+  const rows = await SocialRepository.getFeedActivityRows([userId], fetchLimit);
+  const feedItems = await buildFeedItems(rows);
+
+  return feedItems.slice(0, normalizedLimit);
+};
+
+const cachedGetUserActivityFeed = createTtlCache(getUserActivityFeedUncached, {
+  ttlMs: FEED_CACHE_TTL_MS,
+  keyFn: (userId: string, limit?: number) => `${userId}:${limit ?? ""}`,
+});
+
 export class SocialFeedService {
-  private static async buildFeedItems(
-    rows: ActivityRow[],
-    viewerId?: string,
-  ): Promise<FeedItem[]> {
-    const [reviewContext, postEngagementByPostId, activityEngagementById] = await Promise.all([
-      buildReviewContext(rows, viewerId),
-      buildPostEngagementContext(rows, viewerId),
-      buildActivityEngagementContext(rows, viewerId),
-    ]);
-
-    // Depends on reviewContext (a row only needs a movie fallback lookup
-    // when it has no review-attached movie already), so it can't join the
-    // Promise.all above.
-    const fallbackMedia = await buildFeedFallbackMediaContext(rows, reviewContext);
-
-    const feedItems = rows.map((row) =>
-      toFeedItem(row, reviewContext, postEngagementByPostId, activityEngagementById, fallbackMedia),
-    );
-
-    return dedupeReviewFeedItems(feedItems);
-  }
-
   static async getFeed(userId: string, cursor?: string, limit?: number): Promise<FeedPage> {
     return SocialFeedService.getFollowingFeed(userId, limit, cursor);
   }
@@ -48,39 +106,10 @@ export class SocialFeedService {
     limit?: number,
     cursor?: string,
   ): Promise<FeedPage> {
-    const normalizedLimit = normalizeLimit(limit);
-    const fetchLimit = normalizedLimit * 2;
-    const decodedCursor = decodeFeedCursor(cursor);
-
-    const followingRows = await SocialRepository.getFollowingIdsByFollowerId(userId);
-    const feedUserIds = [...new Set([userId, ...followingRows.map((row) => row.followingId)])];
-
-    const rows = await SocialRepository.getFeedActivityRows(
-      feedUserIds,
-      fetchLimit,
-      decodedCursor,
-    );
-    const items = await SocialFeedService.buildFeedItems(rows, userId);
-
-    // Raw rows (pre-dedupe) filling the fetch cap means there may be more
-    // beyond this page; otherwise we've reached the end of the feed.
-    const hasMore = rows.length === fetchLimit;
-    const lastRow = rows.at(-1);
-    const nextCursor =
-      hasMore && lastRow
-        ? encodeFeedCursor({ createdAt: lastRow.activity.createdAt, id: lastRow.activity.id })
-        : null;
-
-    return { items, nextCursor };
+    return cachedGetFollowingFeed(userId, limit, cursor);
   }
 
   static async getUserActivityFeed(userId: string, limit?: number): Promise<FeedItem[]> {
-    const normalizedLimit = normalizeLimit(limit);
-    const fetchLimit = normalizedLimit * 2;
-
-    const rows = await SocialRepository.getFeedActivityRows([userId], fetchLimit);
-    const feedItems = await SocialFeedService.buildFeedItems(rows);
-
-    return feedItems.slice(0, normalizedLimit);
+    return cachedGetUserActivityFeed(userId, limit);
   }
 }

--- a/apps/api/src/modules/users/services/users-read.service.ts
+++ b/apps/api/src/modules/users/services/users-read.service.ts
@@ -47,12 +47,14 @@ export class UsersReadService {
   }
 
   static async getMeSummary(userId: string) {
-    const profile = await UsersProfileService.findById(userId);
+    const [profile, summaryData] = await Promise.all([
+      UsersProfileService.findById(userId),
+      UsersStatsRepository.getMeSummaryData(userId),
+    ]);
     if (!profile) {
       return null;
     }
 
-    const summaryData = await UsersStatsRepository.getMeSummaryData(userId);
     const recentPosters = dedupeRecentPosters(summaryData.recentRows, 5);
 
     return {

--- a/apps/web/src/features/feed/components/FeedActivityCard.tsx
+++ b/apps/web/src/features/feed/components/FeedActivityCard.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import { memo, type CSSProperties } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { CornerDownRight, Heart, MessageSquare } from "lucide-react";
 import { useAuth } from "@/features/auth/hooks/useAuth";
@@ -141,7 +141,7 @@ const ActivityEngagement = ({ item }: { item: FeedItem }) => {
   );
 };
 
-export const FeedActivityCard = ({ item }: FeedActivityCardProps) => {
+export const FeedActivityCard = memo(function FeedActivityCard({ item }: FeedActivityCardProps) {
   if (item.kind === "post" || item.kind === "liked_post" || item.kind === "commented_post") {
     return <PostActivityCard item={item} />;
   }
@@ -215,4 +215,4 @@ export const FeedActivityCard = ({ item }: FeedActivityCardProps) => {
       <ActivityEngagement item={item} />
     </article>
   );
-};
+});

--- a/apps/web/src/features/feed/components/PostActivityCard.tsx
+++ b/apps/web/src/features/feed/components/PostActivityCard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type CSSProperties, type MouseEvent } from "react";
+import { memo, useMemo, useState, type CSSProperties, type MouseEvent } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { CornerDownRight, Heart, Loader2, MessageSquare, PenSquare } from "lucide-react";
 import { useAuth } from "@/features/auth/hooks/useAuth";
@@ -31,7 +31,7 @@ const getMediaLabel = (item: FeedItem): { title: string; year: string | null } =
   };
 };
 
-export const PostActivityCard = ({ item }: PostActivityCardProps) => {
+export const PostActivityCard = memo(function PostActivityCard({ item }: PostActivityCardProps) {
   const navigate = useNavigate();
   const { user } = useAuth();
 
@@ -229,4 +229,4 @@ export const PostActivityCard = ({ item }: PostActivityCardProps) => {
       ) : null}
     </>
   );
-};
+});

--- a/apps/web/src/features/feed/components/ReviewActivityCard.tsx
+++ b/apps/web/src/features/feed/components/ReviewActivityCard.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties, type MouseEvent } from "react";
+import { memo, useState, type CSSProperties, type MouseEvent } from "react";
 import { Link } from "@tanstack/react-router";
 import {
   CornerDownRight,
@@ -57,7 +57,9 @@ const getReviewBodyFallback = (item: FeedItem): string => {
   return "Shared a review.";
 };
 
-export const ReviewActivityCard = ({ item }: ReviewActivityCardProps) => {
+export const ReviewActivityCard = memo(function ReviewActivityCard({
+  item,
+}: ReviewActivityCardProps) {
   const {
     user,
     actorName,
@@ -250,4 +252,4 @@ export const ReviewActivityCard = ({ item }: ReviewActivityCardProps) => {
       ) : null}
     </>
   );
-};
+});

--- a/apps/web/src/features/films/hooks/useMovies.ts
+++ b/apps/web/src/features/films/hooks/useMovies.ts
@@ -35,11 +35,16 @@ export const useMovieSearch = (query: string) =>
     enabled: query.trim().length >= 2,
   });
 
+// Movie metadata (title/poster/overview/genres) is TMDB-backed and rarely
+// changes within a session, so this can outlive the 30s global default.
+const MOVIE_DETAIL_STALE_TIME_MS = 300_000;
+
 export const useMovieDetail = (tmdbId: number, enabled = true) =>
   useQuery({
     queryKey: movieKeys.detail(tmdbId),
     queryFn: ({ signal }) => getMovieByTmdbId(tmdbId, { signal }),
     enabled,
+    staleTime: MOVIE_DETAIL_STALE_TIME_MS,
   });
 
 export const useMovieDetailView = (
@@ -49,6 +54,9 @@ export const useMovieDetailView = (
 ) =>
   useQuery({
     queryKey: movieKeys.detailView(tmdbId, reviewsSort),
+    // Bundles reviews/ratingBreakdown alongside static movie fields, so it
+    // stays on the global 30s staleTime rather than the longer one below —
+    // those change too often to treat as long-lived.
     queryFn: ({ signal }) => getMovieDetail(tmdbId, { reviewsSort }, { signal }),
     enabled,
   });

--- a/apps/web/src/features/lists/components/ListCard.tsx
+++ b/apps/web/src/features/lists/components/ListCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Link } from "@tanstack/react-router";
 import { formatRelativeTime } from "@/lib/time";
 import type { ListSummary } from "@/features/lists/api";
@@ -14,7 +15,7 @@ type ListCardProps = {
   username: string;
 };
 
-export const ListCard = ({ list, username }: ListCardProps) => {
+export const ListCard = memo(function ListCard({ list, username }: ListCardProps) {
   const covers = list.coverImages.slice(0, 4);
   const coverCount = covers.filter((c) => c.posterPath).length;
 
@@ -134,4 +135,4 @@ export const ListCard = ({ list, username }: ListCardProps) => {
       </div>
     </Link>
   );
-};
+});

--- a/apps/web/src/features/profile/components/LikedListCard.tsx
+++ b/apps/web/src/features/profile/components/LikedListCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Link } from "@tanstack/react-router";
 import type { LikedList } from "@/features/profile/api";
 import { formatRelativeTime } from "@/lib/time";
@@ -11,7 +12,7 @@ const POSTER_W = 48;
 const POSTER_H = 70;
 const CONTAINER_W = POSTER_W + OFFSET * 3;
 
-export const LikedListCard = ({ list }: { list: LikedList }) => {
+export const LikedListCard = memo(function LikedListCard({ list }: { list: LikedList }) {
   const covers = list.coverImages.slice(0, 4);
   const derivedTypeLabel =
     list.derivedType === "cinema"
@@ -96,4 +97,4 @@ export const LikedListCard = ({ list }: { list: LikedList }) => {
       </div>
     </Link>
   );
-};
+});

--- a/apps/web/src/features/profile/components/LikedReviewCard.tsx
+++ b/apps/web/src/features/profile/components/LikedReviewCard.tsx
@@ -1,9 +1,14 @@
+import { memo } from "react";
 import { Link } from "@tanstack/react-router";
 import { getPosterUrl } from "@/features/films/components/utils";
 import type { LikedReview } from "@/features/profile/api";
 import { formatRelativeTime } from "@/lib/time";
 
-export const LikedReviewCard = ({ review }: { review: LikedReview }) => {
+export const LikedReviewCard = memo(function LikedReviewCard({
+  review,
+}: {
+  review: LikedReview;
+}) {
   const route = review.mediaType === "movie" ? "/cinema/$tmdbId" : "/serials/$tmdbId";
   const tmdbId = review.mediaTmdbId;
 
@@ -73,4 +78,4 @@ export const LikedReviewCard = ({ review }: { review: LikedReview }) => {
       </div>
     </div>
   );
-};
+});

--- a/apps/web/src/features/serials/hooks/serials/use-series-queries.ts
+++ b/apps/web/src/features/serials/hooks/serials/use-series-queries.ts
@@ -23,11 +23,17 @@ export const useSerialSearch = (query: string) =>
     enabled: query.trim().length >= 2,
   });
 
+// Series metadata (title/poster/overview/genres/season-episode counts) is
+// TMDB-backed and rarely changes within a session, so this can outlive the
+// 30s global default.
+const SERIES_DETAIL_STALE_TIME_MS = 300_000;
+
 export const useSeriesDetail = (tmdbId: number, enabled = true) =>
   useQuery({
     queryKey: serialKeys.detail(tmdbId),
     queryFn: ({ signal }) => getSeriesByTmdbId(tmdbId, { signal }),
     enabled,
+    staleTime: SERIES_DETAIL_STALE_TIME_MS,
   });
 
 export const useSeriesDetailView = (
@@ -37,6 +43,9 @@ export const useSeriesDetailView = (
 ) =>
   useQuery({
     queryKey: serialKeys.detailView(tmdbId, reviewsSort),
+    // Bundles reviews/ratingBreakdown alongside static series fields, so it
+    // stays on the global 30s staleTime — those change too often to treat
+    // as long-lived.
     queryFn: ({ signal }) => getSeriesDetail(tmdbId, { reviewsSort }, { signal }),
     enabled,
   });


### PR DESCRIPTION
## Summary

Closes issue #18. Implements all 5 performance items, each scoped to a real, traced query pattern or code path rather than a blanket sweep — see per-commit notes below for what was found and why each fix is safe.

### 1. Composite/partial indexes
Traced actual `WHERE`/`ORDER BY` clauses in the repositories rather than guessing:
- `diary_entry` / `serial_diary_entry`: added `(userId, watchedDate, createdAt)` — backs the diary page's `WHERE user_id = X ORDER BY watched_date DESC, created_at DESC`, which previously only had separate single-column indexes and still required a sort.
- `diary_entry`, `movie_interaction`, `serial_diary_entry`, `serial_interaction`: added partial `(movieId/seriesId, rating) WHERE rating IS NOT NULL` — backs the community-rating `avg()` subqueries in `movies.repository.ts`/`serials-archive.repository.ts`. `movie_interaction`/`serial_interaction` previously had **no** index leading with `movieId`/`seriesId` at all (only `unique(userId, movieId)`), so this was a real gap, not just an optimization.
- `list` / `post`: added `(userId, updatedAt/createdAt)` for the profile lists/posts pages.

One deliberate deviation from the issue's own suggested example: it proposes `uniqueIndex().on(userId, movieId)` on `diary_entry`, which would be wrong here since diary intentionally allows multiple entries per user+movie (rewatches). Used non-unique composite indexes instead.

### 2. TMDB cache TTL
`serials-cache.service.ts` already checked `cachedAt` staleness (6h TTL) — `movies-cache.service.ts` never did, so a cached movie row was returned forever once created. Brought movies in line with a 7-day TTL (movies are far more static than still-airing series). Extracted the generic TTL-cache-with-in-flight-dedupe logic out of `tmdb-cache.helper.ts` into a new `infrastructure/cache/ttl-cache.helper.ts` so it isn't TMDB-specific by name/location — `tmdb-cache.helper.ts` now just wraps it with TMDB's existing defaults, so none of its 4 existing call sites needed to change.

### 3. Query parallelization
5 sequential `await` pairs converted to `Promise.all`, each verified as genuinely independent (not just superficially parallel):
- `diary-write.service.ts` `create()`: `setWatched` + `insertActivity`
- `reviews-comments.service.ts` `addComment()`: activity insert + author lookup
- `users-read.service.ts` `getMeSummary()`: profile + stats
- `lists-write.service.ts` `removeItem()`: entry lookup + list lookup
- `lists-write.service.ts` `addItem()`: media cache lookup + max-position lookup

Several near-identical-looking patterns were deliberately **not** touched because they're genuinely dependent (e.g. `people-detail.service.ts`'s primary TMDB call gating 5 follow-up calls — joining them would fire extra requests even when the primary lookup fails).

### 4. Feed cache
Current feed computation is already well-batched (no N+1 loops — batches via `inArray`/`Promise.all` throughout `social-feed-context.helper.ts`), but fully recomputes from scratch on every request with zero reuse across requests. The write paths that would need to invalidate a cache span 6+ modules (diary, reviews, posts, follows, lists, likes/comments), so rather than an invalidate-on-write cache, this uses a 20s in-memory TTL cache (via the new shared `ttl-cache` helper) keyed by `(userId, limit, cursor)` on `SocialFeedService.getFollowingFeed`/`getUserActivityFeed` — short enough that engagement counts don't visibly go stale, long enough to absorb request bursts like React Query's refetch-on-focus or two viewers with overlapping follow sets.

### 5. Frontend
- `React.memo` on `FeedActivityCard`, `PostActivityCard`, `ReviewActivityCard`, `ListCard`, `LikedListCard`, `LikedReviewCard` — all previously un-memoized, all render inside `.map()` on pages with unrelated tab/filter/query state. Matches the existing `ArchiveMovieCard`/`GridSeriesCard`/`SerialReviewCard` pattern.
- Raised `staleTime` to 5 minutes for `useMovieDetail`/`useSeriesDetail` (pure static TMDB-backed fields, no user-generated content). Deliberately left `useMovieDetailView`/`useSeriesDetailView` on the 30s global default since those bundle reviews/rating breakdowns that change too often to treat as long-lived.

## Test plan
- [x] `bun run typecheck && bun run lint && bun run lint:arch` clean in both `apps/api` and `apps/web`
- [x] Backend integration suite: 42/42 pass across all 15 test files
- [x] Frontend test suite: 8/8 pass
- [x] Migration `0038` generated and inspected — 8 pure `CREATE INDEX` statements, no drops/renames; will apply via CI's `drizzle-kit migrate` against `DEVDATABASE_URL`
