### PR TITLE
Refactor: unified API errors and routing registry (#19)

### DIFF
--- a/apps/api/src/commons/errors/app-error.ts
+++ b/apps/api/src/commons/errors/app-error.ts
@@ -1,0 +1,57 @@
+export type ErrorCode =
+  | "BAD_REQUEST"
+  | "VALIDATION_ERROR"
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "PAYLOAD_TOO_LARGE"
+  | "MALFORMED_BODY"
+  | "CORS_NOT_ALLOWED"
+  | "TOO_MANY_REQUESTS"
+  | "SERVICE_UNAVAILABLE"
+  | "INTERNAL_SERVER_ERROR";
+
+export class AppError extends Error {
+  readonly statusCode: number;
+  readonly code: ErrorCode;
+  readonly details?: unknown;
+
+  constructor(statusCode: number, code: ErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "AppError";
+    this.statusCode = statusCode;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export class BadRequestError extends AppError {
+  constructor(message = "Bad request", details?: unknown) {
+    super(400, "BAD_REQUEST", message, details);
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message = "Unauthorized") {
+    super(401, "UNAUTHORIZED", message);
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = "Forbidden") {
+    super(403, "FORBIDDEN", message);
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message = "Not found") {
+    super(404, "NOT_FOUND", message);
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message = "Conflict", details?: unknown) {
+    super(409, "CONFLICT", message, details);
+  }
+}

--- a/apps/api/src/commons/http/validation-response.helper.ts
+++ b/apps/api/src/commons/http/validation-response.helper.ts
@@ -1,13 +1,47 @@
 import type { Response } from "express";
 import { z, type ZodError } from "zod";
+import type { ErrorCode } from "../errors/app-error";
 
-export const sendBadRequest = (res: Response, message: string): void => {
-  res.status(400).json({ error: message });
+type ErrorPayload = { message: string; code: ErrorCode; details?: unknown };
+
+const sendError = (res: Response, status: number, payload: ErrorPayload): void => {
+  res.status(status).json({ error: payload });
 };
 
-export const sendValidationError = (
-  res: Response,
-  error: ZodError,
-): void => {
-  res.status(400).json({ error: z.flattenError(error) });
+export const sendBadRequest = (res: Response, message: string, details?: unknown): void =>
+  sendError(res, 400, { message, code: "BAD_REQUEST", details });
+
+export const sendValidationError = (res: Response, error: ZodError): void =>
+  sendError(res, 400, {
+    message: "Validation failed",
+    code: "VALIDATION_ERROR",
+    details: z.flattenError(error),
+  });
+
+export const sendUnauthorized = (res: Response, message = "Unauthorized"): void =>
+  sendError(res, 401, { message, code: "UNAUTHORIZED" });
+
+export const sendForbidden = (res: Response, message = "Forbidden"): void =>
+  sendError(res, 403, { message, code: "FORBIDDEN" });
+
+export const sendNotFound = (res: Response, message: string): void =>
+  sendError(res, 404, { message, code: "NOT_FOUND" });
+
+export const sendConflict = (res: Response, message: string, details?: unknown): void =>
+  sendError(res, 409, { message, code: "CONFLICT", details });
+
+export const sendServiceUnavailable = (res: Response, message: string): void =>
+  sendError(res, 503, { message, code: "SERVICE_UNAVAILABLE" });
+
+const CODE_BY_STATUS: Partial<Record<number, ErrorCode>> = {
+  400: "BAD_REQUEST",
+  401: "UNAUTHORIZED",
+  403: "FORBIDDEN",
+  404: "NOT_FOUND",
+  409: "CONFLICT",
 };
+
+// For service-layer `{ status, error }` results where the status is only
+// known at the call site (not baked into a specific send* helper above).
+export const sendErrorForStatus = (res: Response, status: number, message: string): void =>
+  sendError(res, status, { message, code: CODE_BY_STATUS[status] ?? "BAD_REQUEST" });

--- a/apps/api/src/commons/middlewares/rateLimiters.ts
+++ b/apps/api/src/commons/middlewares/rateLimiters.ts
@@ -30,12 +30,17 @@ const resolveMax = (production: number, test: number, override?: number): number
   return env.NODE_ENV === "test" ? test : production;
 };
 
+const RATE_LIMIT_MESSAGE = {
+  error: { message: "Too many requests, please try again later.", code: "TOO_MANY_REQUESTS" },
+};
+
 export const createAuthLimiter = (max?: number): RateLimitRequestHandler =>
   rateLimit({
     windowMs: 60 * 1000,
     max: resolveMax(AUTH_LIMIT_PRODUCTION, AUTH_LIMIT_TEST, max),
     standardHeaders: true,
     legacyHeaders: false,
+    message: RATE_LIMIT_MESSAGE,
   });
 
 export const createApiLimiter = (max?: number): RateLimitRequestHandler =>
@@ -44,6 +49,7 @@ export const createApiLimiter = (max?: number): RateLimitRequestHandler =>
     max: resolveMax(API_LIMIT_PRODUCTION, API_LIMIT_TEST, max),
     standardHeaders: true,
     legacyHeaders: false,
+    message: RATE_LIMIT_MESSAGE,
     // public.routes.ts already applies its own dedicated limiter.
     skip: (req) => req.path.startsWith("/public/"),
   });
@@ -59,5 +65,6 @@ export const createMutationLimiter = (max?: number): RateLimitRequestHandler =>
     max: resolveMax(MUTATION_LIMIT_PRODUCTION, MUTATION_LIMIT_TEST, max),
     standardHeaders: true,
     legacyHeaders: false,
+    message: RATE_LIMIT_MESSAGE,
     skip: (req) => SAFE_METHODS.has(req.method),
   });

--- a/apps/api/src/commons/middlewares/requireAdmin.ts
+++ b/apps/api/src/commons/middlewares/requireAdmin.ts
@@ -2,6 +2,7 @@ import type { Request, Response, NextFunction } from "express";
 import { eq } from "drizzle-orm";
 import { db } from "../../infrastructure/database/db";
 import { profiles } from "../../modules/users/users.entity";
+import { sendForbidden } from "../http/validation-response.helper";
 
 export const requireAdmin = async (
   req: Request,
@@ -15,7 +16,7 @@ export const requireAdmin = async (
     .limit(1);
 
   if (!profile || !profile.isAdmin) {
-    res.status(403).json({ error: "Forbidden" });
+    sendForbidden(res);
     return;
   }
 

--- a/apps/api/src/commons/middlewares/requireAuth.ts
+++ b/apps/api/src/commons/middlewares/requireAuth.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import { resolveSessionFromHeaders } from "../auth/session-resolver.helper";
+import { sendUnauthorized } from "../http/validation-response.helper";
 
 export const requireAuth = async (
   req: Request,
@@ -9,7 +10,7 @@ export const requireAuth = async (
   const session = await resolveSessionFromHeaders(req.headers);
 
   if (!session) {
-    res.status(401).json({ error: "Unauthorized" });
+    sendUnauthorized(res);
     return;
   }
 

--- a/apps/api/src/commons/middlewares/requireTrustedOriginForMutations.ts
+++ b/apps/api/src/commons/middlewares/requireTrustedOriginForMutations.ts
@@ -3,6 +3,7 @@ import {
   getOriginFromReferer,
   isTrustedOrigin,
 } from "../../infrastructure/config/origins";
+import { sendForbidden } from "../http/validation-response.helper";
 
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
@@ -36,7 +37,7 @@ export const requireTrustedOriginForMutations = (
     }
 
     if (!isTrustedOrigin(origin, trustedOrigins)) {
-      res.status(403).json({ error: "Invalid origin" });
+      sendForbidden(res, "Invalid origin");
       return;
     }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -23,19 +23,7 @@ import {
   getTrustedOriginsFromEnv,
   isTrustedOrigin,
 } from "./infrastructure/config/origins";
-import listsRouter from "./modules/lists/lists.routes";
-import moviesRouter from "./modules/movies/movies.routes";
-import serialsRouter from "./modules/serials/serials.routes";
-import peopleRouter from "./modules/people/people.routes";
-import diaryRouter from "./modules/diary/diary.routes";
-import usersRouter from "./modules/users/users.routes";
-import reviewsRouter from "./modules/reviews/reviews.routes";
-import socialRouter from "./modules/social/social.routes";
-import interactionsRouter from "./modules/interactions/interactions.routes";
-import uploadsRouter from "./modules/uploads/uploads.routes";
-import publicRouter from "./modules/public/public.routes";
-import postsRouter from "./modules/posts/posts.routes";
-import dataTransferRouter from "./modules/data-transfer/data-transfer.routes";
+import { registerRoutes } from "./infrastructure/routing/register-routes";
 
 export type RateLimiterOverrides = {
   auth?: number;
@@ -97,6 +85,7 @@ export const createApp = (options: CreateAppOptions = {}) => {
         }
 
         const requestId = randomUUID();
+        req.headers["x-request-id"] = requestId;
         res.setHeader("x-request-id", requestId);
         return requestId;
       },
@@ -124,19 +113,7 @@ export const createApp = (options: CreateAppOptions = {}) => {
     res.json({ status: "ok", message: "Interis API is alive" });
   });
 
-  app.use("/api/movies", moviesRouter);
-  app.use("/api/serials", serialsRouter);
-  app.use("/api/people", peopleRouter);
-  app.use("/api/diary", diaryRouter);
-  app.use("/api/users", usersRouter);
-  app.use("/api/reviews", reviewsRouter);
-  app.use("/api/social", socialRouter);
-  app.use("/api/interactions", interactionsRouter);
-  app.use("/api/uploads", uploadsRouter);
-  app.use("/api/public", publicRouter);
-  app.use("/api/posts", postsRouter);
-  app.use("/api/lists", listsRouter);
-  app.use("/api/data", dataTransferRouter);
+  registerRoutes(app);
 
   app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
     if (err instanceof AppError) {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -10,6 +10,7 @@ import { toNodeHandler } from "better-auth/node";
 import { auth } from "./infrastructure/auth/auth";
 import { logger } from "./commons/utils/logger";
 import { env } from "./infrastructure/config/env";
+import { AppError } from "./commons/errors/app-error";
 import { securityHeaders } from "./commons/middlewares/securityHeaders";
 import { helmetMiddleware } from "./commons/middlewares/helmet";
 import { requireTrustedOriginForMutations } from "./commons/middlewares/requireTrustedOriginForMutations";
@@ -138,23 +139,38 @@ export const createApp = (options: CreateAppOptions = {}) => {
   app.use("/api/data", dataTransferRouter);
 
   app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    if (err instanceof AppError) {
+      res
+        .status(err.statusCode)
+        .json({ error: { message: err.message, code: err.code, details: err.details } });
+      return;
+    }
+
     if (err.message === "Not allowed by CORS") {
-      res.status(403).json({ error: "Origin is not allowed" });
+      res
+        .status(403)
+        .json({ error: { message: "Origin is not allowed", code: "CORS_NOT_ALLOWED" } });
       return;
     }
 
     const bodyParserError = err as Error & { type?: string; status?: number };
     if (bodyParserError.type === "entity.too.large") {
-      res.status(413).json({ error: "Request body too large" });
+      res
+        .status(413)
+        .json({ error: { message: "Request body too large", code: "PAYLOAD_TOO_LARGE" } });
       return;
     }
     if (bodyParserError.type?.startsWith("entity.parse")) {
-      res.status(400).json({ error: "Malformed request body" });
+      res
+        .status(400)
+        .json({ error: { message: "Malformed request body", code: "MALFORMED_BODY" } });
       return;
     }
 
     logger.error(err);
-    res.status(500).json({ error: "Internal server error" });
+    res
+      .status(500)
+      .json({ error: { message: "Internal server error", code: "INTERNAL_SERVER_ERROR" } });
   });
 
   return app;

--- a/apps/api/src/infrastructure/routing/register-routes.ts
+++ b/apps/api/src/infrastructure/routing/register-routes.ts
@@ -1,0 +1,30 @@
+import type { Express } from "express";
+import listsRouter from "../../modules/lists/lists.routes";
+import moviesRouter from "../../modules/movies/movies.routes";
+import serialsRouter from "../../modules/serials/serials.routes";
+import peopleRouter from "../../modules/people/people.routes";
+import diaryRouter from "../../modules/diary/diary.routes";
+import usersRouter from "../../modules/users/users.routes";
+import reviewsRouter from "../../modules/reviews/reviews.routes";
+import socialRouter from "../../modules/social/social.routes";
+import interactionsRouter from "../../modules/interactions/interactions.routes";
+import uploadsRouter from "../../modules/uploads/uploads.routes";
+import publicRouter from "../../modules/public/public.routes";
+import postsRouter from "../../modules/posts/posts.routes";
+import dataTransferRouter from "../../modules/data-transfer/data-transfer.routes";
+
+export const registerRoutes = (app: Express): void => {
+  app.use("/api/movies", moviesRouter);
+  app.use("/api/serials", serialsRouter);
+  app.use("/api/people", peopleRouter);
+  app.use("/api/diary", diaryRouter);
+  app.use("/api/users", usersRouter);
+  app.use("/api/reviews", reviewsRouter);
+  app.use("/api/social", socialRouter);
+  app.use("/api/interactions", interactionsRouter);
+  app.use("/api/uploads", uploadsRouter);
+  app.use("/api/public", publicRouter);
+  app.use("/api/posts", postsRouter);
+  app.use("/api/lists", listsRouter);
+  app.use("/api/data", dataTransferRouter);
+};

--- a/apps/api/src/modules/data-transfer/data-transfer.controller.ts
+++ b/apps/api/src/modules/data-transfer/data-transfer.controller.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express";
 import { DataExportService } from "./services/export.service";
 import { DataImportService } from "./services/import.service";
+import { sendBadRequest } from "../../commons/http/validation-response.helper";
 
 export class DataTransferController {
   static async export(req: Request, res: Response): Promise<void> {
@@ -19,7 +20,7 @@ export class DataTransferController {
     const body = req.body;
 
     if (typeof body !== "string" || body.trim().length === 0) {
-      res.status(400).json({ error: "Request body must be a non-empty CSV text." });
+      sendBadRequest(res, "Request body must be a non-empty CSV text.");
       return;
     }
 

--- a/apps/api/src/modules/diary/diary.controller.ts
+++ b/apps/api/src/modules/diary/diary.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { sendValidationError } from "../../commons/http/validation-response.helper";
+import { sendNotFound, sendValidationError } from "../../commons/http/validation-response.helper";
 import { DiaryService } from "./diary.service";
 import { CreateDiarySchema, UpdateDiarySchema } from "./dto/diary.dto";
 
@@ -36,7 +36,7 @@ export class DiaryController {
       parsed.data,
     );
     if (!updated) {
-      res.status(404).json({ error: "Diary entry not found" });
+      sendNotFound(res, "Diary entry not found");
       return;
     }
 
@@ -49,7 +49,7 @@ export class DiaryController {
   ): Promise<void> {
     const deleted = await DiaryService.delete(req.params.id, req.user.id);
     if (!deleted) {
-      res.status(404).json({ error: "Diary entry not found" });
+      sendNotFound(res, "Diary entry not found");
       return;
     }
 

--- a/apps/api/src/modules/diary/services/diary-write.service.ts
+++ b/apps/api/src/modules/diary/services/diary-write.service.ts
@@ -3,12 +3,13 @@ import { MoviesService } from "../../movies/movies.service";
 import { buildDiaryEntryActivityMetadata } from "../helpers/diary-activity.helper";
 import { DiaryRepository } from "../repositories/diary.repository";
 import type { CreateDiaryDto, UpdateDiaryDto } from "../dto/diary.dto";
+import { NotFoundError } from "../../../commons/errors/app-error";
 
 export class DiaryWriteService {
   static async create(userId: string, input: CreateDiaryDto) {
     const movie = await MoviesService.findOrCreate(input.tmdbId);
     if (!movie || !movie.id) {
-      throw new Error("Movie not found");
+      throw new NotFoundError("Movie not found");
     }
 
     const rating = input.rating ?? null;

--- a/apps/api/src/modules/lists/lists.controller.ts
+++ b/apps/api/src/modules/lists/lists.controller.ts
@@ -1,6 +1,10 @@
 import type { Request, Response } from "express";
 import { resolveViewerUserIdFromHeaders } from "../../commons/auth/session-resolver.helper";
-import { sendValidationError } from "../../commons/http/validation-response.helper";
+import {
+  sendErrorForStatus,
+  sendNotFound,
+  sendValidationError,
+} from "../../commons/http/validation-response.helper";
 import {
   AddListItemSchema,
   CreateListSchema,
@@ -19,7 +23,7 @@ export class ListsController {
     const list = await ListsService.getListDetail(req.params.id, viewerUserId);
 
     if (!list) {
-      res.status(404).json({ error: "List not found" });
+      sendNotFound(res, "List not found");
       return;
     }
 
@@ -52,7 +56,7 @@ export class ListsController {
     const result = await ListsService.updateList(req.params.id, req.user.id, parsed.data);
 
     if ("error" in result) {
-      res.status(result.status).json({ error: result.error });
+      sendErrorForStatus(res, result.status, result.error);
       return;
     }
 
@@ -67,7 +71,7 @@ export class ListsController {
     const result = await ListsService.deleteList(req.params.id, req.user.id);
 
     if (result && "error" in result) {
-      res.status(result.status).json({ error: result.error });
+      sendErrorForStatus(res, result.status, result.error);
       return;
     }
 
@@ -93,7 +97,7 @@ export class ListsController {
     );
 
     if ("error" in result) {
-      res.status(result.status).json({ error: result.error });
+      sendErrorForStatus(res, result.status, result.error);
       return;
     }
 
@@ -112,7 +116,7 @@ export class ListsController {
     );
 
     if ("error" in result) {
-      res.status(result.status).json({ error: result.error });
+      sendErrorForStatus(res, result.status, result.error);
       return;
     }
 
@@ -123,7 +127,7 @@ export class ListsController {
   static async like(req: Request<{ id: string }>, res: Response): Promise<void> {
     const result = await ListsService.likeList(req.params.id, req.user.id);
     if ("error" in result) {
-      res.status(result.status as number).json({ error: result.error });
+      sendErrorForStatus(res, result.status, result.error);
       return;
     }
     res.status(200).json(result);
@@ -153,7 +157,7 @@ export class ListsController {
     );
 
     if ("error" in result) {
-      res.status(result.status).json({ error: result.error });
+      sendErrorForStatus(res, result.status, result.error);
       return;
     }
 

--- a/apps/api/src/modules/lists/services/lists-write.service.ts
+++ b/apps/api/src/modules/lists/services/lists-write.service.ts
@@ -198,7 +198,10 @@ export class ListsWriteService {
     return { success: true };
   }
 
-  static async likeList(listId: string, userId: string) {
+  static async likeList(
+    listId: string,
+    userId: string,
+  ): Promise<ServiceError | { success: true; likeCount: number }> {
     const list = await ListsReadRepository.findById(listId);
     if (!list) return { error: "List not found", status: 404 as const };
     if (!list.isPublic && list.userId !== userId)

--- a/apps/api/src/modules/movies/movies.controller.ts
+++ b/apps/api/src/modules/movies/movies.controller.ts
@@ -1,9 +1,6 @@
 import type { Request, Response } from "express";
 import { resolveViewerUserIdFromHeaders } from "../../commons/auth/session-resolver.helper";
-import {
-  sendBadRequest,
-  sendValidationError,
-} from "../../commons/http/validation-response.helper";
+import { sendBadRequest, sendNotFound, sendValidationError } from "../../commons/http/validation-response.helper";
 import { parseTmdbIdParam } from "../../commons/validation/params.helper";
 import { MoviesService } from "./movies.service";
 import type {
@@ -45,7 +42,7 @@ export class MoviesController {
 
     const movie = await MoviesService.findOrCreate(tmdbId);
     if (!movie) {
-      res.status(404).json({ error: "Movie not found" });
+      sendNotFound(res, "Movie not found");
       return;
     }
 
@@ -71,7 +68,7 @@ export class MoviesController {
     });
 
     if (!detail) {
-      res.status(404).json({ error: "Movie not found" });
+      sendNotFound(res, "Movie not found");
       return;
     }
 

--- a/apps/api/src/modules/movies/services/movies-cache.service.ts
+++ b/apps/api/src/modules/movies/services/movies-cache.service.ts
@@ -4,6 +4,7 @@ import {
   type TMDBMovieDetail,
 } from "../../../infrastructure/tmdb/cinemas";
 import { MoviesRepository } from "../repositories/movies.repository";
+import { NotFoundError } from "../../../commons/errors/app-error";
 
 // Released movies rarely change on TMDB (unlike still-airing series), so a
 // long TTL is fine here — this mainly guards against permanently stale
@@ -32,7 +33,7 @@ export class MoviesCacheService {
       return existing;
     }
 
-    throw new Error(`Failed to cache movie for tmdbId=${tmdbId}`);
+    throw new NotFoundError("Movie not found");
   }
 
   static async cacheMovie(tmdbData: TMDBMovieDetail) {

--- a/apps/api/src/modules/people/people.controller.ts
+++ b/apps/api/src/modules/people/people.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { sendBadRequest } from "../../commons/http/validation-response.helper";
+import { sendBadRequest, sendNotFound } from "../../commons/http/validation-response.helper";
 import { normalizePersonRouteSlug } from "./helpers/people-slug.helper";
 import { personRouteRoleSchema, type PersonRouteParams } from "./dto/people.dto";
 import { PeopleDetailService } from "./services/people-detail.service";
@@ -27,7 +27,7 @@ export class PeopleController {
     });
 
     if (!detail) {
-      res.status(404).json({ error: "Person not found" });
+      sendNotFound(res, "Person not found");
       return;
     }
 

--- a/apps/api/src/modules/posts/posts.controller.ts
+++ b/apps/api/src/modules/posts/posts.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { sendValidationError } from "../../commons/http/validation-response.helper";
+import { sendNotFound, sendValidationError } from "../../commons/http/validation-response.helper";
 import { PostsService } from "./posts.service";
 import { CreatePostSchema, PostCommentSchema, UpdatePostSchema } from "./dto/posts.dto";
 
@@ -11,7 +11,7 @@ export class PostsController {
   ): Promise<void> {
     const post = await PostsService.findById(req.params.id);
     if (!post) {
-      res.status(404).json({ error: "Post not found" });
+      sendNotFound(res, "Post not found");
       return;
     }
     res.status(200).json(post);
@@ -36,7 +36,7 @@ export class PostsController {
   ): Promise<void> {
     const deleted = await PostsService.delete(req.params.id, req.user.id);
     if (!deleted) {
-      res.status(404).json({ error: "Post not found" });
+      sendNotFound(res, "Post not found");
       return;
     }
     res.status(200).json({ success: true });
@@ -55,7 +55,7 @@ export class PostsController {
 
     const updated = await PostsService.update(req.params.id, req.user.id, parsed.data);
     if (!updated) {
-      res.status(404).json({ error: "Post not found" });
+      sendNotFound(res, "Post not found");
       return;
     }
 
@@ -78,7 +78,7 @@ export class PostsController {
   ): Promise<void> {
     const result = await PostsService.unlike(req.user.id, req.params.id);
     if (!result) {
-      res.status(404).json({ error: "Like not found" });
+      sendNotFound(res, "Like not found");
       return;
     }
     res.status(200).json({ liked: false });
@@ -110,7 +110,7 @@ export class PostsController {
       parsed.data.content,
     );
     if (!comment) {
-      res.status(404).json({ error: "Post not found" });
+      sendNotFound(res, "Post not found");
       return;
     }
     res.status(201).json(comment);
@@ -126,7 +126,7 @@ export class PostsController {
       req.user.id,
     );
     if (!deleted) {
-      res.status(404).json({ error: "Comment not found" });
+      sendNotFound(res, "Comment not found");
       return;
     }
     res.status(200).json({ success: true });

--- a/apps/api/src/modules/public/public.controller.ts
+++ b/apps/api/src/modules/public/public.controller.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
 import { PublicService } from "./public.service";
+import { sendBadRequest, sendNotFound } from "../../commons/http/validation-response.helper";
 import {
   normalizePublicActivityLimit,
   normalizePublicCollectionLimit,
@@ -17,7 +18,7 @@ import type {
 
 export class PublicController {
   private static sendUserNotFound(res: Response): void {
-    res.status(404).json({ error: "User not found" });
+    sendNotFound(res, "User not found");
   }
 
   private static sendPublicResponse(res: Response, payload: unknown): void {
@@ -227,7 +228,7 @@ export class PublicController {
   ): Promise<void> {
     const tmdbId = Number.parseInt(req.params.tmdbId, 10);
     if (Number.isNaN(tmdbId)) {
-      res.status(400).json({ error: "Invalid tmdbId" });
+      sendBadRequest(res, "Invalid tmdbId");
       return;
     }
 

--- a/apps/api/src/modules/reviews/reviews.controller.ts
+++ b/apps/api/src/modules/reviews/reviews.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { sendValidationError } from "../../commons/http/validation-response.helper";
+import { sendNotFound, sendValidationError } from "../../commons/http/validation-response.helper";
 import { ReviewsService } from "./reviews.service";
 import {
   CreateReviewSchema,
@@ -14,7 +14,7 @@ export class ReviewsController {
   ): Promise<void> {
     const review = await ReviewsService.findById(req.params.id);
     if (!review) {
-      res.status(404).json({ error: "Review not found" });
+      sendNotFound(res, "Review not found");
       return;
     }
     res.status(200).json(review);
@@ -47,7 +47,7 @@ export class ReviewsController {
       parsed.data,
     );
     if (!updated) {
-      res.status(404).json({ error: "Review not found" });
+      sendNotFound(res, "Review not found");
       return;
     }
     res.status(200).json(updated);
@@ -59,7 +59,7 @@ export class ReviewsController {
   ): Promise<void> {
     const deleted = await ReviewsService.delete(req.params.id, req.user.id);
     if (!deleted) {
-      res.status(404).json({ error: "Review not found" });
+      sendNotFound(res, "Review not found");
       return;
     }
     res.status(200).json({ success: true });
@@ -89,7 +89,7 @@ export class ReviewsController {
       parsed.data.content,
     );
     if (!comment) {
-      res.status(404).json({ error: "Review not found" });
+      sendNotFound(res, "Review not found");
       return;
     }
     res.status(201).json(comment);
@@ -104,7 +104,7 @@ export class ReviewsController {
       req.user.id,
     );
     if (!deleted) {
-      res.status(404).json({ error: "Comment not found" });
+      sendNotFound(res, "Comment not found");
       return;
     }
     res.status(200).json({ success: true });
@@ -127,7 +127,7 @@ export class ReviewsController {
       req.params.id,
     );
     if (!result) {
-      res.status(404).json({ error: "Like not found" });
+      sendNotFound(res, "Like not found");
       return;
     }
     res.status(200).json({ liked: false });

--- a/apps/api/src/modules/reviews/services/reviews-core.service.ts
+++ b/apps/api/src/modules/reviews/services/reviews-core.service.ts
@@ -7,12 +7,13 @@ import { activities } from "../../social/social.entity";
 import { reviewLikes, reviews } from "../reviews.entity";
 import { buildReviewCreatedActivityMetadata } from "../helpers/reviews-activity.helper";
 import type { CreateReviewDto, UpdateReviewDto } from "../dto/reviews.dto";
+import { NotFoundError } from "../../../commons/errors/app-error";
 
 export class ReviewsCoreService {
   static async create(userId: string, input: CreateReviewDto) {
     if (input.mediaType === "tv") {
       const series = await SerialsService.findOrCreate(input.tmdbId);
-      if (!series) throw new Error("Series not found");
+      if (!series) throw new NotFoundError("Series not found");
 
       const review = await SerialsReviewsRepository.upsertReview({
         userId,

--- a/apps/api/src/modules/serials/serials-tracking.controller.ts
+++ b/apps/api/src/modules/serials/serials-tracking.controller.ts
@@ -1,8 +1,5 @@
 import type { Request, Response } from "express";
-import {
-  sendBadRequest,
-  sendValidationError,
-} from "../../commons/http/validation-response.helper";
+import { sendBadRequest, sendNotFound, sendValidationError } from "../../commons/http/validation-response.helper";
 import { parseTmdbIdParam } from "../../commons/validation/params.helper";
 import { SerialsTrackingService } from "./services/serials-tracking.service";
 import {
@@ -44,7 +41,7 @@ export class SerialsTrackingController {
     );
 
     if (!result) {
-      res.status(404).json({ error: "Season or series not found" });
+      sendNotFound(res, "Season or series not found");
       return;
     }
 
@@ -79,7 +76,7 @@ export class SerialsTrackingController {
     );
 
     if (!result) {
-      res.status(404).json({ error: "Episode or series not found" });
+      sendNotFound(res, "Episode or series not found");
       return;
     }
 
@@ -157,7 +154,7 @@ export class SerialsTrackingController {
     );
 
     if (!deleted) {
-      res.status(404).json({ error: "Review not found" });
+      sendNotFound(res, "Review not found");
       return;
     }
 
@@ -238,7 +235,7 @@ export class SerialsTrackingController {
     );
 
     if (!deleted) {
-      res.status(404).json({ error: "Review not found" });
+      sendNotFound(res, "Review not found");
       return;
     }
 

--- a/apps/api/src/modules/serials/serials.controller.ts
+++ b/apps/api/src/modules/serials/serials.controller.ts
@@ -1,9 +1,6 @@
 import type { Request, Response } from "express";
 import { resolveViewerUserIdFromHeaders } from "../../commons/auth/session-resolver.helper";
-import {
-  sendBadRequest,
-  sendValidationError,
-} from "../../commons/http/validation-response.helper";
+import { sendBadRequest, sendNotFound, sendValidationError } from "../../commons/http/validation-response.helper";
 import { parseTmdbIdParam } from "../../commons/validation/params.helper";
 import { SerialsService } from "./serials.service";
 import type {
@@ -52,7 +49,7 @@ export class SerialsController {
 
     const series = await SerialsService.findOrCreate(tmdbId);
     if (!series) {
-      res.status(404).json({ error: "Series not found" });
+      sendNotFound(res, "Series not found");
       return;
     }
 
@@ -78,7 +75,7 @@ export class SerialsController {
     });
 
     if (!detail) {
-      res.status(404).json({ error: "Series not found" });
+      sendNotFound(res, "Series not found");
       return;
     }
 
@@ -98,7 +95,7 @@ export class SerialsController {
 
     const state = await SerialsService.getInteraction(req.user.id, tmdbId);
     if (!state) {
-      res.status(404).json({ error: "Series not found" });
+      sendNotFound(res, "Series not found");
       return;
     }
 
@@ -128,7 +125,7 @@ export class SerialsController {
     );
 
     if (!result) {
-      res.status(404).json({ error: "Series not found" });
+      sendNotFound(res, "Series not found");
       return;
     }
 
@@ -153,7 +150,7 @@ export class SerialsController {
 
     const created = await SerialsService.createLog(req.user.id, tmdbId, parsed.data);
     if (!created) {
-      res.status(404).json({ error: "Series not found" });
+      sendNotFound(res, "Series not found");
       return;
     }
 
@@ -185,7 +182,7 @@ export class SerialsController {
     });
 
     if (!seasonDetail) {
-      res.status(404).json({ error: "Season not found" });
+      sendNotFound(res, "Season not found");
       return;
     }
 
@@ -233,7 +230,7 @@ export class SerialsController {
     const { limit, offset } = normalizeSerialLogsQuery(req.query);
     const logs = await SerialsService.getLogs(tmdbId, limit, offset);
     if (logs === null) {
-      res.status(404).json({ error: "Series not found" });
+      sendNotFound(res, "Series not found");
       return;
     }
 
@@ -258,7 +255,7 @@ export class SerialsController {
 
     const updated = await SerialsService.updateLog(req.params.id, req.user.id, parsed.data);
     if (!updated) {
-      res.status(404).json({ error: "Serial log not found" });
+      sendNotFound(res, "Serial log not found");
       return;
     }
 
@@ -271,7 +268,7 @@ export class SerialsController {
   ): Promise<void> {
     const deleted = await SerialsService.deleteLog(req.params.id, req.user.id);
     if (!deleted) {
-      res.status(404).json({ error: "Serial log not found" });
+      sendNotFound(res, "Serial log not found");
       return;
     }
 

--- a/apps/api/src/modules/serials/services/serials-cache.service.ts
+++ b/apps/api/src/modules/serials/services/serials-cache.service.ts
@@ -1,6 +1,7 @@
 import { getSeriesDetails, type TMDBSeriesDetail } from "../../../infrastructure/tmdb/serials";
 import { normalizeTmdbSeriesDetail } from "../helpers/serials-normalization.helper";
 import { SerialsCacheRepository } from "../repositories/serials-cache.repository";
+import { NotFoundError } from "../../../commons/errors/app-error";
 
 // Cached series rows (season/episode counts, status, etc.) go stale for
 // still-airing shows once TMDB publishes a new season - without a refresh,
@@ -33,7 +34,7 @@ export class SerialsCacheService {
       return existing;
     }
 
-    throw new Error(`Failed to cache series for tmdbId=${tmdbId}`);
+    throw new NotFoundError("Series not found");
   }
 
   static async cacheSeries(tmdbData: TMDBSeriesDetail) {

--- a/apps/api/src/modules/social/services/social-follow.service.ts
+++ b/apps/api/src/modules/social/services/social-follow.service.ts
@@ -5,7 +5,7 @@ export class SocialFollowService {
     followerId: string,
     followingId: string,
     targetUsername?: string,
-  ) {
+  ): Promise<{ error: string } | { success: true }> {
     if (followerId === followingId) {
       return { error: "Cannot follow yourself" } as const;
     }

--- a/apps/api/src/modules/social/social.controller.ts
+++ b/apps/api/src/modules/social/social.controller.ts
@@ -3,6 +3,7 @@ import { SocialService } from "./social.service";
 import { UsersService } from "../users/users.service";
 import { normalizeSocialFeedLimit } from "./helpers/social-query-normalizer.helper";
 import type { FeedQueryDto, UsernameParamsDto } from "./dto/social.dto";
+import { sendBadRequest, sendNotFound } from "../../commons/http/validation-response.helper";
 
 export class SocialController {
   static async getFeed(
@@ -29,7 +30,7 @@ export class SocialController {
   ): Promise<void> {
     const target = await UsersService.findByUsername(req.params.username);
     if (!target) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
 
@@ -39,7 +40,7 @@ export class SocialController {
       target.username,
     );
     if ("error" in result) {
-      res.status(400).json({ error: result.error });
+      sendBadRequest(res, result.error);
       return;
     }
     res.status(200).json(result);
@@ -51,7 +52,7 @@ export class SocialController {
   ): Promise<void> {
     const target = await UsersService.findByUsername(req.params.username);
     if (!target) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
 
@@ -65,7 +66,7 @@ export class SocialController {
   ): Promise<void> {
     const target = await UsersService.findByUsername(req.params.username);
     if (!target) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
 
@@ -79,7 +80,7 @@ export class SocialController {
   ): Promise<void> {
     const target = await UsersService.findByUsername(req.params.username);
     if (!target) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
 
@@ -93,7 +94,7 @@ export class SocialController {
   ): Promise<void> {
     const target = await UsersService.findByUsername(req.params.username);
     if (!target) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
 
@@ -107,7 +108,7 @@ export class SocialController {
   ): Promise<void> {
     const follower = await UsersService.findByUsername(req.params.username);
     if (!follower) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
 
@@ -121,7 +122,7 @@ export class SocialController {
   ): Promise<void> {
     const result = await SocialService.likeActivity(req.user.id, req.params.activityId);
     if ("error" in result) {
-      res.status(404).json({ error: result.error });
+      sendNotFound(res, result.error);
       return;
     }
     res.status(200).json(result);

--- a/apps/api/src/modules/social/social.service.ts
+++ b/apps/api/src/modules/social/social.service.ts
@@ -50,7 +50,10 @@ export class SocialService {
     return SocialFeedService.getFollowingFeed(userId, limit, cursor);
   }
 
-  static async likeActivity(userId: string, activityId: string) {
+  static async likeActivity(
+    userId: string,
+    activityId: string,
+  ): Promise<{ error: string } | { success: true }> {
     const activity = await SocialRepository.findActivityById(activityId);
     if (!activity) {
       return { error: "Activity not found" } as const;

--- a/apps/api/src/modules/uploads/uploads.controller.ts
+++ b/apps/api/src/modules/uploads/uploads.controller.ts
@@ -5,7 +5,11 @@ import {
   isOwnedUploadPublicUrl,
   type UploadType,
 } from "../../infrastructure/r2/client";
-import { sendValidationError } from "../../commons/http/validation-response.helper";
+import {
+  sendBadRequest,
+  sendServiceUnavailable,
+  sendValidationError,
+} from "../../commons/http/validation-response.helper";
 import { logger } from "../../commons/utils/logger";
 import { UsersService } from "../users/users.service";
 import { ConfirmUploadSchema, RequestUploadSchema } from "./dto/uploads.dto";
@@ -32,21 +36,21 @@ export class UploadsController {
     } catch (error) {
       if (isR2ConfigurationError(error)) {
         logger.error(error, "R2 uploads are not configured correctly");
-        res.status(503).json({
-          error:
-            "Image uploads are temporarily unavailable. Please configure R2 storage.",
-        });
+        sendServiceUnavailable(
+          res,
+          "Image uploads are temporarily unavailable. Please configure R2 storage.",
+        );
         return;
       }
 
       if (error instanceof Error) {
         if (error.message.startsWith("Unsupported file type")) {
-          res.status(400).json({ error: error.message });
+          sendBadRequest(res, error.message);
           return;
         }
 
         if (error.message.startsWith("File too large")) {
-          res.status(400).json({ error: error.message });
+          sendBadRequest(res, error.message);
           return;
         }
       }
@@ -72,9 +76,7 @@ export class UploadsController {
         parsed.data.publicUrl,
       )
     ) {
-      res.status(400).json({
-        error: "Invalid upload URL. Please request a new signed upload URL.",
-      });
+      sendBadRequest(res, "Invalid upload URL. Please request a new signed upload URL.");
       return;
     }
 

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 import { resolveViewerUserIdFromHeaders } from "../../commons/auth/session-resolver.helper";
-import { sendValidationError } from "../../commons/http/validation-response.helper";
+import { sendNotFound, sendValidationError } from "../../commons/http/validation-response.helper";
 import { ListsService } from "../lists/lists.service";
 import { GetUserListsQuerySchema } from "../lists/dto/lists.dto";
 import { UsersService } from "./users.service";
@@ -39,7 +39,7 @@ export class UsersController {
   ): Promise<void> {
     const profile = await UsersService.findByUsername(req.params.username);
     if (!profile) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
     const stats = await UsersService.getStats(profile.id);
@@ -53,7 +53,7 @@ export class UsersController {
   ): Promise<void> {
     const profile = await UsersService.findByUsername(req.params.username);
     if (!profile) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
     const { limit, offset } = parseProfileListPagination(req.query);
@@ -67,7 +67,7 @@ export class UsersController {
   ): Promise<void> {
     const profile = await UsersService.findByUsername(req.params.username);
     if (!profile) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
 
@@ -79,7 +79,7 @@ export class UsersController {
     );
 
     if (!review) {
-      res.status(404).json({ error: "Review not found" });
+      sendNotFound(res, "Review not found");
       return;
     }
 
@@ -92,7 +92,7 @@ export class UsersController {
   ): Promise<void> {
     const profile = await UsersService.findByUsername(req.params.username);
     if (!profile) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
     const { limit, offset } = parseProfileListPagination(req.query);
@@ -106,7 +106,7 @@ export class UsersController {
   ): Promise<void> {
     const profile = await UsersService.findByUsername(req.params.username);
     if (!profile) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
     const { limit, offset } = parseProfileListPagination(req.query);
@@ -120,7 +120,7 @@ export class UsersController {
   ): Promise<void> {
     const profile = await UsersService.findByUsername(req.params.username);
     if (!profile) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
     const { limit, offset } = parseProfileListPagination(req.query);
@@ -134,7 +134,7 @@ export class UsersController {
   ): Promise<void> {
     const profile = await UsersService.findByUsername(req.params.username);
     if (!profile) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
 
@@ -146,7 +146,7 @@ export class UsersController {
   static async getMe(req: Request, res: Response): Promise<void> {
     const profile = await UsersService.findById(req.user.id);
     if (!profile) {
-      res.status(404).json({ error: "Profile not found" });
+      sendNotFound(res, "Profile not found");
       return;
     }
     res.status(200).json(profile);
@@ -155,7 +155,7 @@ export class UsersController {
   static async getMeSummary(req: Request, res: Response): Promise<void> {
     const summary = await UsersService.getMeSummary(req.user.id);
     if (!summary) {
-      res.status(404).json({ error: "Profile not found" });
+      sendNotFound(res, "Profile not found");
       return;
     }
 
@@ -185,7 +185,7 @@ export class UsersController {
     );
 
     if (!updated) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
 
@@ -204,7 +204,7 @@ export class UsersController {
 
     const profile = await UsersService.findByUsername(req.params.username);
     if (!profile) {
-      res.status(404).json({ error: "User not found" });
+      sendNotFound(res, "User not found");
       return;
     }
 

--- a/apps/api/tests/integration/lists/item-cap.test.ts
+++ b/apps/api/tests/integration/lists/item-cap.test.ts
@@ -68,7 +68,7 @@ describe("list item cap", () => {
       jar,
     );
     expect(addResponse.status).toBe(400);
-    const body = (await addResponse.json()) as { error: string };
-    expect(body.error).toContain(String(MAX_LIST_ITEMS));
+    const body = (await addResponse.json()) as { error: { message: string } };
+    expect(body.error.message).toContain(String(MAX_LIST_ITEMS));
   });
 });

--- a/apps/api/tests/integration/security/cors-csrf.test.ts
+++ b/apps/api/tests/integration/security/cors-csrf.test.ts
@@ -53,8 +53,9 @@ describe("CORS + CSRF origin enforcement", () => {
     );
 
     expect(response.status).toBe(403);
-    const body = (await response.json()) as { error: string };
-    expect(body.error).toBe("Origin is not allowed");
+    const body = (await response.json()) as { error: { message: string; code: string } };
+    expect(body.error.message).toBe("Origin is not allowed");
+    expect(body.error.code).toBe("CORS_NOT_ALLOWED");
   });
 
   it("rejects a mutation with no Origin but an untrusted Referer", async () => {
@@ -75,8 +76,9 @@ describe("CORS + CSRF origin enforcement", () => {
     );
 
     expect(response.status).toBe(403);
-    const body = (await response.json()) as { error: string };
-    expect(body.error).toBe("Invalid origin");
+    const body = (await response.json()) as { error: { message: string; code: string } };
+    expect(body.error.message).toBe("Invalid origin");
+    expect(body.error.code).toBe("FORBIDDEN");
   });
 
   it("allows a mutation from a trusted Origin to reach routing", async () => {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -19,6 +19,14 @@ const extractErrorMessage = (
       return candidate.error;
     }
 
+    // Unified backend error shape: { error: { message, code, details } }.
+    if (candidate.error && typeof candidate.error === "object") {
+      const nestedMessage = (candidate.error as { message?: unknown }).message;
+      if (typeof nestedMessage === "string" && nestedMessage.trim().length > 0) {
+        return nestedMessage;
+      }
+    }
+
     if (
       typeof candidate.message === "string" &&
       candidate.message.trim().length > 0


### PR DESCRIPTION
## Summary
Closes #19 (items 2-4; item 1 — static classes → DI — intentionally skipped, see note below).

- **Structured logging (item 2):** already fully in place (Pino + `pino-http`, JSON in prod, redaction) — no changes needed.
- **Unified API errors (item 3):** added an `AppError` hierarchy (`commons/errors/app-error.ts`) and `send*` response helpers producing `{ error: { message, code, details } }`. Rewired the global error handler, all auth/admin/CORS-origin/rate-limit middleware, and ~60 inline error-response call sites across every controller to the same shape. Also fixed 3 latent bugs where "not found" lookups (bad/nonexistent movie or series tmdbId, activity like target) fell through to an undeserved 500 instead of a 404 — `movies.controller.ts` even had dead `if (!movie) sendNotFound(...)` code that could never be reached because the underlying service always threw first.
- **Routing architecture (item 4):** extracted the 13 `app.use("/api/x", router)` calls out of `index.ts` into `infrastructure/routing/register-routes.ts`. Also propagated the generated request id onto `req.headers`, not just the response header.
- **Frontend:** `api-client.ts`'s `extractErrorMessage` now also parses the new nested `error.message` shape (previously only handled a flat string), so error toasts/messages keep working.

### Item 1 — static classes → DI: intentionally skipped
The issue asks to convert static classes to instantiable/DI-friendly modules, but this repo's `CLAUDE.md` explicitly documents controllers/services/repositories as static classes as the intended architecture (78 files use this pattern). Converting all of them would be a large, high-risk rewrite that reverses the documented design rather than extending it. Discussed and confirmed with the repo owner to skip this item.

## Test plan
- [x] `bun run typecheck` (api + web)
- [x] `bun run lint` (api + web)
- [x] `bun run lint:arch`
- [x] `bun run test:ci` — 42/42 backend integration tests pass
- [x] `bun run test` — 8/8 frontend tests pass
- [x] Manual smoke test against a running dev server: verified `{error:{message,code,[details]}}` shape live for 404 (not-found), 400 (bad param + validation), 401 (unauthorized), 403 (CORS rejection), and confirmed `x-request-id` response header