### PR TITLE
Feature: unified search, block/mute, notifications, reporting, admin dashboard (#20)

### DIFF
--- a/apps/api/drizzle/0039_mighty_tinkerer.sql
+++ b/apps/api/drizzle/0039_mighty_tinkerer.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "user_block" (
+	"blocker_id" text NOT NULL,
+	"blocked_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "user_blocks_unique" UNIQUE("blocker_id","blocked_id")
+);
+--> statement-breakpoint
+CREATE TABLE "user_mute" (
+	"muter_id" text NOT NULL,
+	"muted_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "user_mutes_unique" UNIQUE("muter_id","muted_id")
+);
+--> statement-breakpoint
+ALTER TABLE "user_block" ADD CONSTRAINT "user_block_blocker_id_user_id_fk" FOREIGN KEY ("blocker_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_block" ADD CONSTRAINT "user_block_blocked_id_user_id_fk" FOREIGN KEY ("blocked_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_mute" ADD CONSTRAINT "user_mute_muter_id_user_id_fk" FOREIGN KEY ("muter_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_mute" ADD CONSTRAINT "user_mute_muted_id_user_id_fk" FOREIGN KEY ("muted_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "user_blocks_blocked_id_idx" ON "user_block" USING btree ("blocked_id");--> statement-breakpoint
+CREATE INDEX "user_mutes_muted_id_idx" ON "user_mute" USING btree ("muted_id");

--- a/apps/api/drizzle/0040_unique_toad_men.sql
+++ b/apps/api/drizzle/0040_unique_toad_men.sql
@@ -1,0 +1,16 @@
+CREATE TYPE "public"."notification_type" AS ENUM('follow', 'like_review', 'like_post', 'like_activity', 'comment_review', 'comment_post');--> statement-breakpoint
+CREATE TABLE "notification" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"recipient_id" text NOT NULL,
+	"actor_id" text NOT NULL,
+	"type" "notification_type" NOT NULL,
+	"entity_id" text NOT NULL,
+	"metadata" text,
+	"is_read" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "notification" ADD CONSTRAINT "notification_recipient_id_user_id_fk" FOREIGN KEY ("recipient_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notification" ADD CONSTRAINT "notification_actor_id_user_id_fk" FOREIGN KEY ("actor_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "notification_recipient_created_idx" ON "notification" USING btree ("recipient_id","created_at");--> statement-breakpoint
+CREATE INDEX "notification_recipient_unread_idx" ON "notification" USING btree ("recipient_id","is_read");

--- a/apps/api/drizzle/0041_calm_husk.sql
+++ b/apps/api/drizzle/0041_calm_husk.sql
@@ -1,0 +1,21 @@
+CREATE TYPE "public"."report_reason" AS ENUM('spam', 'harassment', 'inappropriate', 'other');--> statement-breakpoint
+CREATE TYPE "public"."report_status" AS ENUM('pending', 'resolved', 'dismissed');--> statement-breakpoint
+CREATE TYPE "public"."report_target_type" AS ENUM('review', 'post');--> statement-breakpoint
+CREATE TABLE "report" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"reporter_id" text NOT NULL,
+	"target_type" "report_target_type" NOT NULL,
+	"target_id" text NOT NULL,
+	"content_snapshot" text NOT NULL,
+	"reason" "report_reason" NOT NULL,
+	"details" text,
+	"status" "report_status" DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"resolved_at" timestamp,
+	"resolved_by" text,
+	CONSTRAINT "reports_reporter_target_unique" UNIQUE("reporter_id","target_type","target_id")
+);
+--> statement-breakpoint
+ALTER TABLE "report" ADD CONSTRAINT "report_reporter_id_user_id_fk" FOREIGN KEY ("reporter_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "report" ADD CONSTRAINT "report_resolved_by_user_id_fk" FOREIGN KEY ("resolved_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "reports_status_created_idx" ON "report" USING btree ("status","created_at");

--- a/apps/api/drizzle/meta/0039_snapshot.json
+++ b/apps/api/drizzle/meta/0039_snapshot.json
@@ -1,0 +1,3228 @@
+{
+  "id": "3e58289d-bc33-4d6c-b139-0308b53e5c96",
+  "prevId": "f875b2af-ab16-4e58-a765-011980d384e2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movie": {
+      "name": "movie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "director": {
+          "name": "director",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movie_tmdb_id_unique": {
+          "name": "movie_tmdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_diary_entry": {
+      "name": "serial_diary_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched_date": {
+          "name": "watched_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewatch": {
+          "name": "rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "serial_diary_entry_user_id_idx": {
+          "name": "serial_diary_entry_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serial_diary_entry_series_id_idx": {
+          "name": "serial_diary_entry_series_id_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serial_diary_entry_user_watched_created_idx": {
+          "name": "serial_diary_entry_user_watched_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "watched_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serial_diary_entry_series_rating_idx": {
+          "name": "serial_diary_entry_series_rating_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "serial_diary_entry_user_id_user_id_fk": {
+          "name": "serial_diary_entry_user_id_user_id_fk",
+          "tableFrom": "serial_diary_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_diary_entry_series_id_tv_series_id_fk": {
+          "name": "serial_diary_entry_series_id_tv_series_id_fk",
+          "tableFrom": "serial_diary_entry",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_episode_interaction": {
+      "name": "serial_episode_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched": {
+          "name": "watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "serial_episode_interaction_user_id_user_id_fk": {
+          "name": "serial_episode_interaction_user_id_user_id_fk",
+          "tableFrom": "serial_episode_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_episode_interaction_series_id_tv_series_id_fk": {
+          "name": "serial_episode_interaction_series_id_tv_series_id_fk",
+          "tableFrom": "serial_episode_interaction",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "serial_episode_interactions_unique": {
+          "name": "serial_episode_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series_id",
+            "season_number",
+            "episode_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_interaction": {
+      "name": "serial_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "watchlisted": {
+          "name": "watchlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_watched": {
+          "name": "is_watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "serial_interaction_series_rating_idx": {
+          "name": "serial_interaction_series_rating_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "serial_interaction_user_id_user_id_fk": {
+          "name": "serial_interaction_user_id_user_id_fk",
+          "tableFrom": "serial_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_interaction_series_id_tv_series_id_fk": {
+          "name": "serial_interaction_series_id_tv_series_id_fk",
+          "tableFrom": "serial_interaction",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "serial_interactions_unique": {
+          "name": "serial_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_season_interaction": {
+      "name": "serial_season_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched": {
+          "name": "watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "serial_season_interaction_user_id_user_id_fk": {
+          "name": "serial_season_interaction_user_id_user_id_fk",
+          "tableFrom": "serial_season_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_season_interaction_series_id_tv_series_id_fk": {
+          "name": "serial_season_interaction_series_id_tv_series_id_fk",
+          "tableFrom": "serial_season_interaction",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "serial_season_interactions_unique": {
+          "name": "serial_season_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series_id",
+            "season_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tv_series": {
+      "name": "tv_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_air_date": {
+          "name": "first_air_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_air_year": {
+          "name": "first_air_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_air_date": {
+          "name": "last_air_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "episode_runtime": {
+          "name": "episode_runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_seasons": {
+          "name": "number_of_seasons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_episodes": {
+          "name": "number_of_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tv_series_tmdb_id_unique": {
+          "name": "tv_series_tmdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person": {
+      "name": "person",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_person_id": {
+          "name": "tmdb_person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "known_for_department": {
+          "name": "known_for_department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_role_hints": {
+          "name": "route_role_hints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "profile_path": {
+          "name": "profile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_tmdb_person_id_unique": {
+          "name": "person_tmdb_person_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_person_id"
+          ]
+        },
+        "person_slug_unique": {
+          "name": "person_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_slug_alias": {
+      "name": "person_slug_alias",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_slug_alias_person_id_idx": {
+          "name": "person_slug_alias_person_id_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_slug_alias_person_id_person_id_fk": {
+          "name": "person_slug_alias_person_id_person_id_fk",
+          "tableFrom": "person_slug_alias",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_slug_alias_slug_unique": {
+          "name": "person_slug_alias_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_top_pick": {
+      "name": "profile_top_pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_source": {
+          "name": "media_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tmdb'"
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_top_pick_user_id_user_id_fk": {
+          "name": "profile_top_pick_user_id_user_id_fk",
+          "tableFrom": "profile_top_pick",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_top_pick_user_category_slot_unique": {
+          "name": "profile_top_pick_user_category_slot_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "category_id",
+            "slot"
+          ]
+        },
+        "profile_top_pick_user_category_media_unique": {
+          "name": "profile_top_pick_user_category_media_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "category_id",
+            "media_source",
+            "media_source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_genres": {
+          "name": "favorite_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rose-pine'"
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_user_id_user_id_fk": {
+          "name": "profile_user_id_user_id_fk",
+          "tableFrom": "profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diary_entry": {
+      "name": "diary_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched_date": {
+          "name": "watched_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewatch": {
+          "name": "rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diary_entry_user_id_idx": {
+          "name": "diary_entry_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entry_movie_id_idx": {
+          "name": "diary_entry_movie_id_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entry_user_watched_created_idx": {
+          "name": "diary_entry_user_watched_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "watched_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entry_movie_rating_idx": {
+          "name": "diary_entry_movie_rating_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "diary_entry_user_id_user_id_fk": {
+          "name": "diary_entry_user_id_user_id_fk",
+          "tableFrom": "diary_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "diary_entry_movie_id_movie_id_fk": {
+          "name": "diary_entry_movie_id_movie_id_fk",
+          "tableFrom": "diary_entry",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_like": {
+      "name": "comment_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comment_like_user_id_user_id_fk": {
+          "name": "comment_like_user_id_user_id_fk",
+          "tableFrom": "comment_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_like_comment_id_comment_id_fk": {
+          "name": "comment_like_comment_id_comment_id_fk",
+          "tableFrom": "comment_like",
+          "tableTo": "comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comment_likes_unique": {
+          "name": "comment_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "comment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_review_id_idx": {
+          "name": "comment_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_user_id_user_id_fk": {
+          "name": "comment_user_id_user_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_review_id_review_id_fk": {
+          "name": "comment_review_id_review_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "review",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_like": {
+      "name": "review_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_like_user_id_user_id_fk": {
+          "name": "review_like_user_id_user_id_fk",
+          "tableFrom": "review_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_like_review_id_review_id_fk": {
+          "name": "review_like_review_id_review_id_fk",
+          "tableFrom": "review_like",
+          "tableTo": "review",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "review_likes_unique": {
+          "name": "review_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "review_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'movie'"
+        },
+        "media_source": {
+          "name": "media_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tmdb'"
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diary_entry_id": {
+          "name": "diary_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contains_spoilers": {
+          "name": "contains_spoilers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_movie_id_idx": {
+          "name": "review_movie_id_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_diary_entry_id_idx": {
+          "name": "review_diary_entry_id_idx",
+          "columns": [
+            {
+              "expression": "diary_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_user_id_user_id_fk": {
+          "name": "review_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_movie_id_movie_id_fk": {
+          "name": "review_movie_id_movie_id_fk",
+          "tableFrom": "review",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_user_media_unique": {
+          "name": "reviews_user_media_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "media_type",
+            "media_source",
+            "media_source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movie_interaction": {
+      "name": "movie_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "watchlisted": {
+          "name": "watchlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_watched": {
+          "name": "is_watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "movie_interaction_movie_rating_idx": {
+          "name": "movie_interaction_movie_rating_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "movie_interaction_user_id_user_id_fk": {
+          "name": "movie_interaction_user_id_user_id_fk",
+          "tableFrom": "movie_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "movie_interaction_movie_id_movie_id_fk": {
+          "name": "movie_interaction_movie_id_movie_id_fk",
+          "tableFrom": "movie_interaction",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movie_interactions_unique": {
+          "name": "movie_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "movie_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_comment": {
+      "name": "post_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_comment_post_id_idx": {
+          "name": "post_comment_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_comment_user_id_user_id_fk": {
+          "name": "post_comment_user_id_user_id_fk",
+          "tableFrom": "post_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comment_post_id_post_id_fk": {
+          "name": "post_comment_post_id_post_id_fk",
+          "tableFrom": "post_comment",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_like": {
+      "name": "post_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_like_user_id_user_id_fk": {
+          "name": "post_like_user_id_user_id_fk",
+          "tableFrom": "post_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_like_post_id_post_id_fk": {
+          "name": "post_like_post_id_post_id_fk",
+          "tableFrom": "post_like",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_likes_unique": {
+          "name": "post_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post": {
+      "name": "post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "post_media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_user_id_idx": {
+          "name": "post_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_media_id_idx": {
+          "name": "post_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_user_created_idx": {
+          "name": "post_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_user_id_user_id_fk": {
+          "name": "post_user_id_user_id_fk",
+          "tableFrom": "post",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_user_id_created_at_idx": {
+          "name": "activity_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_user_id_user_id_fk": {
+          "name": "activity_user_id_user_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_like": {
+      "name": "activity_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_like_user_id_user_id_fk": {
+          "name": "activity_like_user_id_user_id_fk",
+          "tableFrom": "activity_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_like_activity_id_activity_id_fk": {
+          "name": "activity_like_activity_id_activity_id_fk",
+          "tableFrom": "activity_like",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "activity_likes_unique": {
+          "name": "activity_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "activity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follow": {
+      "name": "follow",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follows_following_id_idx": {
+          "name": "follows_following_id_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_follower_id_user_id_fk": {
+          "name": "follow_follower_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follow_following_id_user_id_fk": {
+          "name": "follow_following_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follows_unique": {
+          "name": "follows_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_entry": {
+      "name": "list_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tv_series_id": {
+          "name": "tv_series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "le_cinema_unique": {
+          "name": "le_cinema_unique",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "movie_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "le_serial_unique": {
+          "name": "le_serial_unique",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tv_series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "tv_series_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "list_entry_list_id_list_id_fk": {
+          "name": "list_entry_list_id_list_id_fk",
+          "tableFrom": "list_entry",
+          "tableTo": "list",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_entry_movie_id_movie_id_fk": {
+          "name": "list_entry_movie_id_movie_id_fk",
+          "tableFrom": "list_entry",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_entry_tv_series_id_tv_series_id_fk": {
+          "name": "list_entry_tv_series_id_tv_series_id_fk",
+          "tableFrom": "list_entry",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "tv_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_like": {
+      "name": "list_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_like_user_id_user_id_fk": {
+          "name": "list_like_user_id_user_id_fk",
+          "tableFrom": "list_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_like_list_id_list_id_fk": {
+          "name": "list_like_list_id_list_id_fk",
+          "tableFrom": "list_like",
+          "tableTo": "list",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "list_likes_unique": {
+          "name": "list_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "list_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list": {
+      "name": "list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ranked": {
+          "name": "is_ranked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "derived_type": {
+          "name": "derived_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_user_id_idx": {
+          "name": "list_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_user_updated_idx": {
+          "name": "list_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "list_user_id_user_id_fk": {
+          "name": "list_user_id_user_id_fk",
+          "tableFrom": "list",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_block": {
+      "name": "user_block",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_blocks_blocked_id_idx": {
+          "name": "user_blocks_blocked_id_idx",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_block_blocker_id_user_id_fk": {
+          "name": "user_block_blocker_id_user_id_fk",
+          "tableFrom": "user_block",
+          "tableTo": "user",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_block_blocked_id_user_id_fk": {
+          "name": "user_block_blocked_id_user_id_fk",
+          "tableFrom": "user_block",
+          "tableTo": "user",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_blocks_unique": {
+          "name": "user_blocks_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_mute": {
+      "name": "user_mute",
+      "schema": "",
+      "columns": {
+        "muter_id": {
+          "name": "muter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_id": {
+          "name": "muted_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_mutes_muted_id_idx": {
+          "name": "user_mutes_muted_id_idx",
+          "columns": [
+            {
+              "expression": "muted_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mute_muter_id_user_id_fk": {
+          "name": "user_mute_muter_id_user_id_fk",
+          "tableFrom": "user_mute",
+          "tableTo": "user",
+          "columnsFrom": [
+            "muter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mute_muted_id_user_id_fk": {
+          "name": "user_mute_muted_id_user_id_fk",
+          "tableFrom": "user_mute",
+          "tableTo": "user",
+          "columnsFrom": [
+            "muted_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_mutes_unique": {
+          "name": "user_mutes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "muter_id",
+            "muted_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.post_media_type": {
+      "name": "post_media_type",
+      "schema": "public",
+      "values": [
+        "movie",
+        "tv"
+      ]
+    },
+    "public.activity_type": {
+      "name": "activity_type",
+      "schema": "public",
+      "values": [
+        "diary_entry",
+        "review",
+        "liked_movie",
+        "watchlisted_movie",
+        "followed_user",
+        "created_list",
+        "liked_review",
+        "commented",
+        "post"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/0040_snapshot.json
+++ b/apps/api/drizzle/meta/0040_snapshot.json
@@ -1,0 +1,3374 @@
+{
+  "id": "b9dda7aa-5e53-46e3-9dc5-b0f1510581df",
+  "prevId": "3e58289d-bc33-4d6c-b139-0308b53e5c96",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movie": {
+      "name": "movie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "director": {
+          "name": "director",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movie_tmdb_id_unique": {
+          "name": "movie_tmdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_diary_entry": {
+      "name": "serial_diary_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched_date": {
+          "name": "watched_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewatch": {
+          "name": "rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "serial_diary_entry_user_id_idx": {
+          "name": "serial_diary_entry_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serial_diary_entry_series_id_idx": {
+          "name": "serial_diary_entry_series_id_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serial_diary_entry_user_watched_created_idx": {
+          "name": "serial_diary_entry_user_watched_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "watched_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serial_diary_entry_series_rating_idx": {
+          "name": "serial_diary_entry_series_rating_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "serial_diary_entry_user_id_user_id_fk": {
+          "name": "serial_diary_entry_user_id_user_id_fk",
+          "tableFrom": "serial_diary_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_diary_entry_series_id_tv_series_id_fk": {
+          "name": "serial_diary_entry_series_id_tv_series_id_fk",
+          "tableFrom": "serial_diary_entry",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_episode_interaction": {
+      "name": "serial_episode_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched": {
+          "name": "watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "serial_episode_interaction_user_id_user_id_fk": {
+          "name": "serial_episode_interaction_user_id_user_id_fk",
+          "tableFrom": "serial_episode_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_episode_interaction_series_id_tv_series_id_fk": {
+          "name": "serial_episode_interaction_series_id_tv_series_id_fk",
+          "tableFrom": "serial_episode_interaction",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "serial_episode_interactions_unique": {
+          "name": "serial_episode_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series_id",
+            "season_number",
+            "episode_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_interaction": {
+      "name": "serial_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "watchlisted": {
+          "name": "watchlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_watched": {
+          "name": "is_watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "serial_interaction_series_rating_idx": {
+          "name": "serial_interaction_series_rating_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "serial_interaction_user_id_user_id_fk": {
+          "name": "serial_interaction_user_id_user_id_fk",
+          "tableFrom": "serial_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_interaction_series_id_tv_series_id_fk": {
+          "name": "serial_interaction_series_id_tv_series_id_fk",
+          "tableFrom": "serial_interaction",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "serial_interactions_unique": {
+          "name": "serial_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_season_interaction": {
+      "name": "serial_season_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched": {
+          "name": "watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "serial_season_interaction_user_id_user_id_fk": {
+          "name": "serial_season_interaction_user_id_user_id_fk",
+          "tableFrom": "serial_season_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_season_interaction_series_id_tv_series_id_fk": {
+          "name": "serial_season_interaction_series_id_tv_series_id_fk",
+          "tableFrom": "serial_season_interaction",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "serial_season_interactions_unique": {
+          "name": "serial_season_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series_id",
+            "season_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tv_series": {
+      "name": "tv_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_air_date": {
+          "name": "first_air_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_air_year": {
+          "name": "first_air_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_air_date": {
+          "name": "last_air_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "episode_runtime": {
+          "name": "episode_runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_seasons": {
+          "name": "number_of_seasons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_episodes": {
+          "name": "number_of_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tv_series_tmdb_id_unique": {
+          "name": "tv_series_tmdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person": {
+      "name": "person",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_person_id": {
+          "name": "tmdb_person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "known_for_department": {
+          "name": "known_for_department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_role_hints": {
+          "name": "route_role_hints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "profile_path": {
+          "name": "profile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_tmdb_person_id_unique": {
+          "name": "person_tmdb_person_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_person_id"
+          ]
+        },
+        "person_slug_unique": {
+          "name": "person_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_slug_alias": {
+      "name": "person_slug_alias",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_slug_alias_person_id_idx": {
+          "name": "person_slug_alias_person_id_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_slug_alias_person_id_person_id_fk": {
+          "name": "person_slug_alias_person_id_person_id_fk",
+          "tableFrom": "person_slug_alias",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_slug_alias_slug_unique": {
+          "name": "person_slug_alias_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_top_pick": {
+      "name": "profile_top_pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_source": {
+          "name": "media_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tmdb'"
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_top_pick_user_id_user_id_fk": {
+          "name": "profile_top_pick_user_id_user_id_fk",
+          "tableFrom": "profile_top_pick",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_top_pick_user_category_slot_unique": {
+          "name": "profile_top_pick_user_category_slot_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "category_id",
+            "slot"
+          ]
+        },
+        "profile_top_pick_user_category_media_unique": {
+          "name": "profile_top_pick_user_category_media_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "category_id",
+            "media_source",
+            "media_source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_genres": {
+          "name": "favorite_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rose-pine'"
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_user_id_user_id_fk": {
+          "name": "profile_user_id_user_id_fk",
+          "tableFrom": "profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diary_entry": {
+      "name": "diary_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched_date": {
+          "name": "watched_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewatch": {
+          "name": "rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diary_entry_user_id_idx": {
+          "name": "diary_entry_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entry_movie_id_idx": {
+          "name": "diary_entry_movie_id_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entry_user_watched_created_idx": {
+          "name": "diary_entry_user_watched_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "watched_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entry_movie_rating_idx": {
+          "name": "diary_entry_movie_rating_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "diary_entry_user_id_user_id_fk": {
+          "name": "diary_entry_user_id_user_id_fk",
+          "tableFrom": "diary_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "diary_entry_movie_id_movie_id_fk": {
+          "name": "diary_entry_movie_id_movie_id_fk",
+          "tableFrom": "diary_entry",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_like": {
+      "name": "comment_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comment_like_user_id_user_id_fk": {
+          "name": "comment_like_user_id_user_id_fk",
+          "tableFrom": "comment_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_like_comment_id_comment_id_fk": {
+          "name": "comment_like_comment_id_comment_id_fk",
+          "tableFrom": "comment_like",
+          "tableTo": "comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comment_likes_unique": {
+          "name": "comment_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "comment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_review_id_idx": {
+          "name": "comment_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_user_id_user_id_fk": {
+          "name": "comment_user_id_user_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_review_id_review_id_fk": {
+          "name": "comment_review_id_review_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "review",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_like": {
+      "name": "review_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_like_user_id_user_id_fk": {
+          "name": "review_like_user_id_user_id_fk",
+          "tableFrom": "review_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_like_review_id_review_id_fk": {
+          "name": "review_like_review_id_review_id_fk",
+          "tableFrom": "review_like",
+          "tableTo": "review",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "review_likes_unique": {
+          "name": "review_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "review_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'movie'"
+        },
+        "media_source": {
+          "name": "media_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tmdb'"
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diary_entry_id": {
+          "name": "diary_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contains_spoilers": {
+          "name": "contains_spoilers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_movie_id_idx": {
+          "name": "review_movie_id_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_diary_entry_id_idx": {
+          "name": "review_diary_entry_id_idx",
+          "columns": [
+            {
+              "expression": "diary_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_user_id_user_id_fk": {
+          "name": "review_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_movie_id_movie_id_fk": {
+          "name": "review_movie_id_movie_id_fk",
+          "tableFrom": "review",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_user_media_unique": {
+          "name": "reviews_user_media_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "media_type",
+            "media_source",
+            "media_source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movie_interaction": {
+      "name": "movie_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "watchlisted": {
+          "name": "watchlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_watched": {
+          "name": "is_watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "movie_interaction_movie_rating_idx": {
+          "name": "movie_interaction_movie_rating_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "movie_interaction_user_id_user_id_fk": {
+          "name": "movie_interaction_user_id_user_id_fk",
+          "tableFrom": "movie_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "movie_interaction_movie_id_movie_id_fk": {
+          "name": "movie_interaction_movie_id_movie_id_fk",
+          "tableFrom": "movie_interaction",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movie_interactions_unique": {
+          "name": "movie_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "movie_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_comment": {
+      "name": "post_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_comment_post_id_idx": {
+          "name": "post_comment_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_comment_user_id_user_id_fk": {
+          "name": "post_comment_user_id_user_id_fk",
+          "tableFrom": "post_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comment_post_id_post_id_fk": {
+          "name": "post_comment_post_id_post_id_fk",
+          "tableFrom": "post_comment",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_like": {
+      "name": "post_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_like_user_id_user_id_fk": {
+          "name": "post_like_user_id_user_id_fk",
+          "tableFrom": "post_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_like_post_id_post_id_fk": {
+          "name": "post_like_post_id_post_id_fk",
+          "tableFrom": "post_like",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_likes_unique": {
+          "name": "post_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post": {
+      "name": "post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "post_media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_user_id_idx": {
+          "name": "post_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_media_id_idx": {
+          "name": "post_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_user_created_idx": {
+          "name": "post_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_user_id_user_id_fk": {
+          "name": "post_user_id_user_id_fk",
+          "tableFrom": "post",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_user_id_created_at_idx": {
+          "name": "activity_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_user_id_user_id_fk": {
+          "name": "activity_user_id_user_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_like": {
+      "name": "activity_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_like_user_id_user_id_fk": {
+          "name": "activity_like_user_id_user_id_fk",
+          "tableFrom": "activity_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_like_activity_id_activity_id_fk": {
+          "name": "activity_like_activity_id_activity_id_fk",
+          "tableFrom": "activity_like",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "activity_likes_unique": {
+          "name": "activity_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "activity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follow": {
+      "name": "follow",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follows_following_id_idx": {
+          "name": "follows_following_id_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_follower_id_user_id_fk": {
+          "name": "follow_follower_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follow_following_id_user_id_fk": {
+          "name": "follow_following_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follows_unique": {
+          "name": "follows_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_entry": {
+      "name": "list_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tv_series_id": {
+          "name": "tv_series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "le_cinema_unique": {
+          "name": "le_cinema_unique",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "movie_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "le_serial_unique": {
+          "name": "le_serial_unique",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tv_series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "tv_series_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "list_entry_list_id_list_id_fk": {
+          "name": "list_entry_list_id_list_id_fk",
+          "tableFrom": "list_entry",
+          "tableTo": "list",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_entry_movie_id_movie_id_fk": {
+          "name": "list_entry_movie_id_movie_id_fk",
+          "tableFrom": "list_entry",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_entry_tv_series_id_tv_series_id_fk": {
+          "name": "list_entry_tv_series_id_tv_series_id_fk",
+          "tableFrom": "list_entry",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "tv_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_like": {
+      "name": "list_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_like_user_id_user_id_fk": {
+          "name": "list_like_user_id_user_id_fk",
+          "tableFrom": "list_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_like_list_id_list_id_fk": {
+          "name": "list_like_list_id_list_id_fk",
+          "tableFrom": "list_like",
+          "tableTo": "list",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "list_likes_unique": {
+          "name": "list_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "list_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list": {
+      "name": "list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ranked": {
+          "name": "is_ranked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "derived_type": {
+          "name": "derived_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_user_id_idx": {
+          "name": "list_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_user_updated_idx": {
+          "name": "list_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "list_user_id_user_id_fk": {
+          "name": "list_user_id_user_id_fk",
+          "tableFrom": "list",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_block": {
+      "name": "user_block",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_blocks_blocked_id_idx": {
+          "name": "user_blocks_blocked_id_idx",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_block_blocker_id_user_id_fk": {
+          "name": "user_block_blocker_id_user_id_fk",
+          "tableFrom": "user_block",
+          "tableTo": "user",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_block_blocked_id_user_id_fk": {
+          "name": "user_block_blocked_id_user_id_fk",
+          "tableFrom": "user_block",
+          "tableTo": "user",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_blocks_unique": {
+          "name": "user_blocks_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_mute": {
+      "name": "user_mute",
+      "schema": "",
+      "columns": {
+        "muter_id": {
+          "name": "muter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_id": {
+          "name": "muted_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_mutes_muted_id_idx": {
+          "name": "user_mutes_muted_id_idx",
+          "columns": [
+            {
+              "expression": "muted_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mute_muter_id_user_id_fk": {
+          "name": "user_mute_muter_id_user_id_fk",
+          "tableFrom": "user_mute",
+          "tableTo": "user",
+          "columnsFrom": [
+            "muter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mute_muted_id_user_id_fk": {
+          "name": "user_mute_muted_id_user_id_fk",
+          "tableFrom": "user_mute",
+          "tableTo": "user",
+          "columnsFrom": [
+            "muted_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_mutes_unique": {
+          "name": "user_mutes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "muter_id",
+            "muted_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_recipient_created_idx": {
+          "name": "notification_recipient_created_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_recipient_unread_idx": {
+          "name": "notification_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_recipient_id_user_id_fk": {
+          "name": "notification_recipient_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_actor_id_user_id_fk": {
+          "name": "notification_actor_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.post_media_type": {
+      "name": "post_media_type",
+      "schema": "public",
+      "values": [
+        "movie",
+        "tv"
+      ]
+    },
+    "public.activity_type": {
+      "name": "activity_type",
+      "schema": "public",
+      "values": [
+        "diary_entry",
+        "review",
+        "liked_movie",
+        "watchlisted_movie",
+        "followed_user",
+        "created_list",
+        "liked_review",
+        "commented",
+        "post"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "follow",
+        "like_review",
+        "like_post",
+        "like_activity",
+        "comment_review",
+        "comment_post"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/0041_snapshot.json
+++ b/apps/api/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,3544 @@
+{
+  "id": "f9e6c3ea-4473-4b90-9a92-b4e3dffa0cd5",
+  "prevId": "b9dda7aa-5e53-46e3-9dc5-b0f1510581df",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movie": {
+      "name": "movie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "director": {
+          "name": "director",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movie_tmdb_id_unique": {
+          "name": "movie_tmdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_diary_entry": {
+      "name": "serial_diary_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched_date": {
+          "name": "watched_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewatch": {
+          "name": "rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "serial_diary_entry_user_id_idx": {
+          "name": "serial_diary_entry_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serial_diary_entry_series_id_idx": {
+          "name": "serial_diary_entry_series_id_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serial_diary_entry_user_watched_created_idx": {
+          "name": "serial_diary_entry_user_watched_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "watched_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serial_diary_entry_series_rating_idx": {
+          "name": "serial_diary_entry_series_rating_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "serial_diary_entry_user_id_user_id_fk": {
+          "name": "serial_diary_entry_user_id_user_id_fk",
+          "tableFrom": "serial_diary_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_diary_entry_series_id_tv_series_id_fk": {
+          "name": "serial_diary_entry_series_id_tv_series_id_fk",
+          "tableFrom": "serial_diary_entry",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_episode_interaction": {
+      "name": "serial_episode_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched": {
+          "name": "watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "serial_episode_interaction_user_id_user_id_fk": {
+          "name": "serial_episode_interaction_user_id_user_id_fk",
+          "tableFrom": "serial_episode_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_episode_interaction_series_id_tv_series_id_fk": {
+          "name": "serial_episode_interaction_series_id_tv_series_id_fk",
+          "tableFrom": "serial_episode_interaction",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "serial_episode_interactions_unique": {
+          "name": "serial_episode_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series_id",
+            "season_number",
+            "episode_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_interaction": {
+      "name": "serial_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "watchlisted": {
+          "name": "watchlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_watched": {
+          "name": "is_watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "serial_interaction_series_rating_idx": {
+          "name": "serial_interaction_series_rating_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "serial_interaction_user_id_user_id_fk": {
+          "name": "serial_interaction_user_id_user_id_fk",
+          "tableFrom": "serial_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_interaction_series_id_tv_series_id_fk": {
+          "name": "serial_interaction_series_id_tv_series_id_fk",
+          "tableFrom": "serial_interaction",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "serial_interactions_unique": {
+          "name": "serial_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serial_season_interaction": {
+      "name": "serial_season_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched": {
+          "name": "watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "serial_season_interaction_user_id_user_id_fk": {
+          "name": "serial_season_interaction_user_id_user_id_fk",
+          "tableFrom": "serial_season_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serial_season_interaction_series_id_tv_series_id_fk": {
+          "name": "serial_season_interaction_series_id_tv_series_id_fk",
+          "tableFrom": "serial_season_interaction",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "serial_season_interactions_unique": {
+          "name": "serial_season_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series_id",
+            "season_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tv_series": {
+      "name": "tv_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_air_date": {
+          "name": "first_air_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_air_year": {
+          "name": "first_air_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_air_date": {
+          "name": "last_air_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "episode_runtime": {
+          "name": "episode_runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_seasons": {
+          "name": "number_of_seasons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_episodes": {
+          "name": "number_of_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tv_series_tmdb_id_unique": {
+          "name": "tv_series_tmdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person": {
+      "name": "person",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_person_id": {
+          "name": "tmdb_person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "known_for_department": {
+          "name": "known_for_department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_role_hints": {
+          "name": "route_role_hints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "profile_path": {
+          "name": "profile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_tmdb_person_id_unique": {
+          "name": "person_tmdb_person_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_person_id"
+          ]
+        },
+        "person_slug_unique": {
+          "name": "person_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_slug_alias": {
+      "name": "person_slug_alias",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_slug_alias_person_id_idx": {
+          "name": "person_slug_alias_person_id_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_slug_alias_person_id_person_id_fk": {
+          "name": "person_slug_alias_person_id_person_id_fk",
+          "tableFrom": "person_slug_alias",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "person_slug_alias_slug_unique": {
+          "name": "person_slug_alias_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_top_pick": {
+      "name": "profile_top_pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_source": {
+          "name": "media_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tmdb'"
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_top_pick_user_id_user_id_fk": {
+          "name": "profile_top_pick_user_id_user_id_fk",
+          "tableFrom": "profile_top_pick",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_top_pick_user_category_slot_unique": {
+          "name": "profile_top_pick_user_category_slot_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "category_id",
+            "slot"
+          ]
+        },
+        "profile_top_pick_user_category_media_unique": {
+          "name": "profile_top_pick_user_category_media_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "category_id",
+            "media_source",
+            "media_source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_genres": {
+          "name": "favorite_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rose-pine'"
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_user_id_user_id_fk": {
+          "name": "profile_user_id_user_id_fk",
+          "tableFrom": "profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diary_entry": {
+      "name": "diary_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched_date": {
+          "name": "watched_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewatch": {
+          "name": "rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diary_entry_user_id_idx": {
+          "name": "diary_entry_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entry_movie_id_idx": {
+          "name": "diary_entry_movie_id_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entry_user_watched_created_idx": {
+          "name": "diary_entry_user_watched_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "watched_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diary_entry_movie_rating_idx": {
+          "name": "diary_entry_movie_rating_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "diary_entry_user_id_user_id_fk": {
+          "name": "diary_entry_user_id_user_id_fk",
+          "tableFrom": "diary_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "diary_entry_movie_id_movie_id_fk": {
+          "name": "diary_entry_movie_id_movie_id_fk",
+          "tableFrom": "diary_entry",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_like": {
+      "name": "comment_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comment_like_user_id_user_id_fk": {
+          "name": "comment_like_user_id_user_id_fk",
+          "tableFrom": "comment_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_like_comment_id_comment_id_fk": {
+          "name": "comment_like_comment_id_comment_id_fk",
+          "tableFrom": "comment_like",
+          "tableTo": "comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comment_likes_unique": {
+          "name": "comment_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "comment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_review_id_idx": {
+          "name": "comment_review_id_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_user_id_user_id_fk": {
+          "name": "comment_user_id_user_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_review_id_review_id_fk": {
+          "name": "comment_review_id_review_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "review",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_like": {
+      "name": "review_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_like_user_id_user_id_fk": {
+          "name": "review_like_user_id_user_id_fk",
+          "tableFrom": "review_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_like_review_id_review_id_fk": {
+          "name": "review_like_review_id_review_id_fk",
+          "tableFrom": "review_like",
+          "tableTo": "review",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "review_likes_unique": {
+          "name": "review_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "review_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'movie'"
+        },
+        "media_source": {
+          "name": "media_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tmdb'"
+        },
+        "media_source_id": {
+          "name": "media_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diary_entry_id": {
+          "name": "diary_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contains_spoilers": {
+          "name": "contains_spoilers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_movie_id_idx": {
+          "name": "review_movie_id_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_diary_entry_id_idx": {
+          "name": "review_diary_entry_id_idx",
+          "columns": [
+            {
+              "expression": "diary_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_user_id_user_id_fk": {
+          "name": "review_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_movie_id_movie_id_fk": {
+          "name": "review_movie_id_movie_id_fk",
+          "tableFrom": "review",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_user_media_unique": {
+          "name": "reviews_user_media_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "media_type",
+            "media_source",
+            "media_source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movie_interaction": {
+      "name": "movie_interaction",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liked": {
+          "name": "liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "watchlisted": {
+          "name": "watchlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_watched": {
+          "name": "is_watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "movie_interaction_movie_rating_idx": {
+          "name": "movie_interaction_movie_rating_idx",
+          "columns": [
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "rating is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "movie_interaction_user_id_user_id_fk": {
+          "name": "movie_interaction_user_id_user_id_fk",
+          "tableFrom": "movie_interaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "movie_interaction_movie_id_movie_id_fk": {
+          "name": "movie_interaction_movie_id_movie_id_fk",
+          "tableFrom": "movie_interaction",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movie_interactions_unique": {
+          "name": "movie_interactions_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "movie_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_comment": {
+      "name": "post_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_comment_post_id_idx": {
+          "name": "post_comment_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_comment_user_id_user_id_fk": {
+          "name": "post_comment_user_id_user_id_fk",
+          "tableFrom": "post_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comment_post_id_post_id_fk": {
+          "name": "post_comment_post_id_post_id_fk",
+          "tableFrom": "post_comment",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_like": {
+      "name": "post_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_like_user_id_user_id_fk": {
+          "name": "post_like_user_id_user_id_fk",
+          "tableFrom": "post_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_like_post_id_post_id_fk": {
+          "name": "post_like_post_id_post_id_fk",
+          "tableFrom": "post_like",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_likes_unique": {
+          "name": "post_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post": {
+      "name": "post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "post_media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_user_id_idx": {
+          "name": "post_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_media_id_idx": {
+          "name": "post_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_user_created_idx": {
+          "name": "post_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_user_id_user_id_fk": {
+          "name": "post_user_id_user_id_fk",
+          "tableFrom": "post",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_user_id_created_at_idx": {
+          "name": "activity_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_user_id_user_id_fk": {
+          "name": "activity_user_id_user_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_like": {
+      "name": "activity_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_like_user_id_user_id_fk": {
+          "name": "activity_like_user_id_user_id_fk",
+          "tableFrom": "activity_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_like_activity_id_activity_id_fk": {
+          "name": "activity_like_activity_id_activity_id_fk",
+          "tableFrom": "activity_like",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "activity_likes_unique": {
+          "name": "activity_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "activity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follow": {
+      "name": "follow",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follows_following_id_idx": {
+          "name": "follows_following_id_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_follower_id_user_id_fk": {
+          "name": "follow_follower_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follow_following_id_user_id_fk": {
+          "name": "follow_following_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follows_unique": {
+          "name": "follows_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_entry": {
+      "name": "list_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tv_series_id": {
+          "name": "tv_series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "le_cinema_unique": {
+          "name": "le_cinema_unique",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "movie_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "movie_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "le_serial_unique": {
+          "name": "le_serial_unique",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tv_series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "tv_series_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "list_entry_list_id_list_id_fk": {
+          "name": "list_entry_list_id_list_id_fk",
+          "tableFrom": "list_entry",
+          "tableTo": "list",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_entry_movie_id_movie_id_fk": {
+          "name": "list_entry_movie_id_movie_id_fk",
+          "tableFrom": "list_entry",
+          "tableTo": "movie",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_entry_tv_series_id_tv_series_id_fk": {
+          "name": "list_entry_tv_series_id_tv_series_id_fk",
+          "tableFrom": "list_entry",
+          "tableTo": "tv_series",
+          "columnsFrom": [
+            "tv_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_like": {
+      "name": "list_like",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_like_user_id_user_id_fk": {
+          "name": "list_like_user_id_user_id_fk",
+          "tableFrom": "list_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_like_list_id_list_id_fk": {
+          "name": "list_like_list_id_list_id_fk",
+          "tableFrom": "list_like",
+          "tableTo": "list",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "list_likes_unique": {
+          "name": "list_likes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "list_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list": {
+      "name": "list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ranked": {
+          "name": "is_ranked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "derived_type": {
+          "name": "derived_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_user_id_idx": {
+          "name": "list_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_user_updated_idx": {
+          "name": "list_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "list_user_id_user_id_fk": {
+          "name": "list_user_id_user_id_fk",
+          "tableFrom": "list",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_block": {
+      "name": "user_block",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_blocks_blocked_id_idx": {
+          "name": "user_blocks_blocked_id_idx",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_block_blocker_id_user_id_fk": {
+          "name": "user_block_blocker_id_user_id_fk",
+          "tableFrom": "user_block",
+          "tableTo": "user",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_block_blocked_id_user_id_fk": {
+          "name": "user_block_blocked_id_user_id_fk",
+          "tableFrom": "user_block",
+          "tableTo": "user",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_blocks_unique": {
+          "name": "user_blocks_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_mute": {
+      "name": "user_mute",
+      "schema": "",
+      "columns": {
+        "muter_id": {
+          "name": "muter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_id": {
+          "name": "muted_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_mutes_muted_id_idx": {
+          "name": "user_mutes_muted_id_idx",
+          "columns": [
+            {
+              "expression": "muted_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mute_muter_id_user_id_fk": {
+          "name": "user_mute_muter_id_user_id_fk",
+          "tableFrom": "user_mute",
+          "tableTo": "user",
+          "columnsFrom": [
+            "muter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mute_muted_id_user_id_fk": {
+          "name": "user_mute_muted_id_user_id_fk",
+          "tableFrom": "user_mute",
+          "tableTo": "user",
+          "columnsFrom": [
+            "muted_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_mutes_unique": {
+          "name": "user_mutes_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "muter_id",
+            "muted_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_recipient_created_idx": {
+          "name": "notification_recipient_created_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_recipient_unread_idx": {
+          "name": "notification_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_recipient_id_user_id_fk": {
+          "name": "notification_recipient_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_actor_id_user_id_fk": {
+          "name": "notification_actor_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report": {
+      "name": "report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "report_target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "report_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reports_status_created_idx": {
+          "name": "reports_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_reporter_id_user_id_fk": {
+          "name": "report_reporter_id_user_id_fk",
+          "tableFrom": "report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_resolved_by_user_id_fk": {
+          "name": "report_resolved_by_user_id_fk",
+          "tableFrom": "report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reports_reporter_target_unique": {
+          "name": "reports_reporter_target_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reporter_id",
+            "target_type",
+            "target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.post_media_type": {
+      "name": "post_media_type",
+      "schema": "public",
+      "values": [
+        "movie",
+        "tv"
+      ]
+    },
+    "public.activity_type": {
+      "name": "activity_type",
+      "schema": "public",
+      "values": [
+        "diary_entry",
+        "review",
+        "liked_movie",
+        "watchlisted_movie",
+        "followed_user",
+        "created_list",
+        "liked_review",
+        "commented",
+        "post"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "follow",
+        "like_review",
+        "like_post",
+        "like_activity",
+        "comment_review",
+        "comment_post"
+      ]
+    },
+    "public.report_reason": {
+      "name": "report_reason",
+      "schema": "public",
+      "values": [
+        "spam",
+        "harassment",
+        "inappropriate",
+        "other"
+      ]
+    },
+    "public.report_status": {
+      "name": "report_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "resolved",
+        "dismissed"
+      ]
+    },
+    "public.report_target_type": {
+      "name": "report_target_type",
+      "schema": "public",
+      "values": [
+        "review",
+        "post"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1784228270155,
       "tag": "0038_good_molten_man",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1784300690241,
+      "tag": "0039_mighty_tinkerer",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1784300690241,
       "tag": "0039_mighty_tinkerer",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1784303762514,
+      "tag": "0040_unique_toad_men",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1784303762514,
       "tag": "0040_unique_toad_men",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1784307297771,
+      "tag": "0041_calm_husk",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
     "dev": "bun run --watch src/index.ts",
     "start": "bun run src/index.ts",
     "test": "bun test",
-    "test:integration": "bun test tests/integration",
+    "test:integration": "bun test tests/integration --timeout 15000",
     "test:contract": "bun test tests/contract",
     "test:db:migrate": "bunx drizzle-kit migrate",
     "test:db:reset": "bun run scripts/test-db-reset.ts",

--- a/apps/api/src/infrastructure/database/entities.ts
+++ b/apps/api/src/infrastructure/database/entities.ts
@@ -13,3 +13,4 @@ export * from "../../modules/interactions/interactions.entity";
 export * from "../../modules/posts/posts.entity";
 export * from "../../modules/social/social.entity";
 export * from "../../modules/lists/lists.entity";
+export * from "../../modules/moderation/moderation.entity";

--- a/apps/api/src/infrastructure/database/entities.ts
+++ b/apps/api/src/infrastructure/database/entities.ts
@@ -15,3 +15,4 @@ export * from "../../modules/social/social.entity";
 export * from "../../modules/lists/lists.entity";
 export * from "../../modules/moderation/moderation.entity";
 export * from "../../modules/notifications/notifications.entity";
+export * from "../../modules/reports/reports.entity";

--- a/apps/api/src/infrastructure/database/entities.ts
+++ b/apps/api/src/infrastructure/database/entities.ts
@@ -14,3 +14,4 @@ export * from "../../modules/posts/posts.entity";
 export * from "../../modules/social/social.entity";
 export * from "../../modules/lists/lists.entity";
 export * from "../../modules/moderation/moderation.entity";
+export * from "../../modules/notifications/notifications.entity";

--- a/apps/api/src/infrastructure/routing/register-routes.ts
+++ b/apps/api/src/infrastructure/routing/register-routes.ts
@@ -14,10 +14,12 @@ import postsRouter from "../../modules/posts/posts.routes";
 import dataTransferRouter from "../../modules/data-transfer/data-transfer.routes";
 import searchRouter from "../../modules/search/search.routes";
 import moderationRouter from "../../modules/moderation/moderation.routes";
+import notificationsRouter from "../../modules/notifications/notifications.routes";
 
 export const registerRoutes = (app: Express): void => {
   app.use("/api/search", searchRouter);
   app.use("/api/moderation", moderationRouter);
+  app.use("/api/notifications", notificationsRouter);
   app.use("/api/movies", moviesRouter);
   app.use("/api/serials", serialsRouter);
   app.use("/api/people", peopleRouter);

--- a/apps/api/src/infrastructure/routing/register-routes.ts
+++ b/apps/api/src/infrastructure/routing/register-routes.ts
@@ -15,11 +15,13 @@ import dataTransferRouter from "../../modules/data-transfer/data-transfer.routes
 import searchRouter from "../../modules/search/search.routes";
 import moderationRouter from "../../modules/moderation/moderation.routes";
 import notificationsRouter from "../../modules/notifications/notifications.routes";
+import reportsRouter from "../../modules/reports/reports.routes";
 
 export const registerRoutes = (app: Express): void => {
   app.use("/api/search", searchRouter);
   app.use("/api/moderation", moderationRouter);
   app.use("/api/notifications", notificationsRouter);
+  app.use("/api/reports", reportsRouter);
   app.use("/api/movies", moviesRouter);
   app.use("/api/serials", serialsRouter);
   app.use("/api/people", peopleRouter);

--- a/apps/api/src/infrastructure/routing/register-routes.ts
+++ b/apps/api/src/infrastructure/routing/register-routes.ts
@@ -13,9 +13,11 @@ import publicRouter from "../../modules/public/public.routes";
 import postsRouter from "../../modules/posts/posts.routes";
 import dataTransferRouter from "../../modules/data-transfer/data-transfer.routes";
 import searchRouter from "../../modules/search/search.routes";
+import moderationRouter from "../../modules/moderation/moderation.routes";
 
 export const registerRoutes = (app: Express): void => {
   app.use("/api/search", searchRouter);
+  app.use("/api/moderation", moderationRouter);
   app.use("/api/movies", moviesRouter);
   app.use("/api/serials", serialsRouter);
   app.use("/api/people", peopleRouter);

--- a/apps/api/src/infrastructure/routing/register-routes.ts
+++ b/apps/api/src/infrastructure/routing/register-routes.ts
@@ -16,12 +16,14 @@ import searchRouter from "../../modules/search/search.routes";
 import moderationRouter from "../../modules/moderation/moderation.routes";
 import notificationsRouter from "../../modules/notifications/notifications.routes";
 import reportsRouter from "../../modules/reports/reports.routes";
+import adminRouter from "../../modules/admin/admin.routes";
 
 export const registerRoutes = (app: Express): void => {
   app.use("/api/search", searchRouter);
   app.use("/api/moderation", moderationRouter);
   app.use("/api/notifications", notificationsRouter);
   app.use("/api/reports", reportsRouter);
+  app.use("/api/admin", adminRouter);
   app.use("/api/movies", moviesRouter);
   app.use("/api/serials", serialsRouter);
   app.use("/api/people", peopleRouter);

--- a/apps/api/src/infrastructure/routing/register-routes.ts
+++ b/apps/api/src/infrastructure/routing/register-routes.ts
@@ -12,8 +12,10 @@ import uploadsRouter from "../../modules/uploads/uploads.routes";
 import publicRouter from "../../modules/public/public.routes";
 import postsRouter from "../../modules/posts/posts.routes";
 import dataTransferRouter from "../../modules/data-transfer/data-transfer.routes";
+import searchRouter from "../../modules/search/search.routes";
 
 export const registerRoutes = (app: Express): void => {
+  app.use("/api/search", searchRouter);
   app.use("/api/movies", moviesRouter);
   app.use("/api/serials", serialsRouter);
   app.use("/api/people", peopleRouter);

--- a/apps/api/src/infrastructure/tmdb/dto/cinemas-response.dto.ts
+++ b/apps/api/src/infrastructure/tmdb/dto/cinemas-response.dto.ts
@@ -6,6 +6,7 @@ export const TMDBSearchMovieSchema = z.object({
   poster_path: z.string().nullable(),
   release_date: z.string().default(""),
   overview: z.string().default(""),
+  popularity: z.number().default(0),
 });
 
 export const TMDBMovieDetailSchema = z.object({
@@ -54,6 +55,7 @@ export const TMDBDiscoverMovieSchema = z.object({
   vote_count: z.number().int().default(0),
   overview: z.string().default(""),
   genre_ids: z.array(z.number()).default([]),
+  popularity: z.number().default(0),
 });
 
 export const TMDBDiscoverMoviesSchema = z.object({

--- a/apps/api/src/infrastructure/tmdb/dto/serials-response.dto.ts
+++ b/apps/api/src/infrastructure/tmdb/dto/serials-response.dto.ts
@@ -6,6 +6,7 @@ export const TMDBSearchSeriesSchema = z.object({
   poster_path: z.string().nullable(),
   first_air_date: z.string().nullable().default(null),
   overview: z.string().default(""),
+  popularity: z.number().default(0),
 });
 
 export const TMDBSeriesGenreSchema = z.object({
@@ -28,6 +29,7 @@ export const TMDBDiscoverSeriesSchema = z.object({
   vote_count: z.number().int().default(0),
   overview: z.string().default(""),
   genre_ids: z.array(z.number()).default([]),
+  popularity: z.number().default(0),
 });
 
 export const TMDBDiscoverSeriesListSchema = z.object({

--- a/apps/api/src/modules/admin/admin.controller.ts
+++ b/apps/api/src/modules/admin/admin.controller.ts
@@ -1,0 +1,24 @@
+import type { Request, Response } from "express";
+import { sendValidationError } from "../../commons/http/validation-response.helper";
+import { AdminService } from "./admin.service";
+import { ListUsersQuerySchema, type ListUsersQuery } from "./dto/admin.dto";
+
+export class AdminController {
+  static async listUsers(
+    req: Request<{}, {}, {}, ListUsersQuery>,
+    res: Response,
+  ): Promise<void> {
+    const parsed = ListUsersQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      sendValidationError(res, parsed.error);
+      return;
+    }
+
+    const users = await AdminService.listUsers(
+      parsed.data.query,
+      parsed.data.limit ?? 20,
+      parsed.data.offset ?? 0,
+    );
+    res.status(200).json(users);
+  }
+}

--- a/apps/api/src/modules/admin/admin.routes.ts
+++ b/apps/api/src/modules/admin/admin.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { AdminController } from "./admin.controller";
+import { asyncHandler } from "../../commons/utils/asyncHandler";
+import { requireAuth } from "../../commons/middlewares/requireAuth";
+import { requireAdmin } from "../../commons/middlewares/requireAdmin";
+
+const router = Router();
+
+router.use(requireAuth, requireAdmin);
+
+router.get("/users", asyncHandler(AdminController.listUsers));
+
+export default router;

--- a/apps/api/src/modules/admin/admin.service.ts
+++ b/apps/api/src/modules/admin/admin.service.ts
@@ -1,0 +1,7 @@
+import { AdminRepository } from "./repositories/admin.repository";
+
+export class AdminService {
+  static async listUsers(query: string | undefined, limit: number, offset: number) {
+    return AdminRepository.listUsers(query, limit, offset);
+  }
+}

--- a/apps/api/src/modules/admin/dto/admin.dto.ts
+++ b/apps/api/src/modules/admin/dto/admin.dto.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const ListUsersQuerySchema = z.object({
+  query: z.string().trim().optional(),
+  limit: z.coerce.number().int().positive().max(100).optional(),
+  offset: z.coerce.number().int().nonnegative().optional(),
+});
+
+export type ListUsersQuery = z.input<typeof ListUsersQuerySchema>;

--- a/apps/api/src/modules/admin/repositories/admin.repository.ts
+++ b/apps/api/src/modules/admin/repositories/admin.repository.ts
@@ -1,0 +1,25 @@
+import { desc, eq, ilike } from "drizzle-orm";
+import { db } from "../../../infrastructure/database/db";
+import { user } from "../../../infrastructure/database/auth.entity";
+import { profiles } from "../../users/users.entity";
+
+export class AdminRepository {
+  static async listUsers(query: string | undefined, limit: number, offset: number) {
+    return db
+      .select({
+        id: user.id,
+        username: user.username,
+        displayUsername: user.displayUsername,
+        email: user.email,
+        avatarUrl: profiles.avatarUrl,
+        isAdmin: profiles.isAdmin,
+        createdAt: profiles.createdAt,
+      })
+      .from(user)
+      .innerJoin(profiles, eq(user.id, profiles.userId))
+      .where(query ? ilike(user.username, `%${query}%`) : undefined)
+      .orderBy(desc(profiles.createdAt))
+      .limit(limit)
+      .offset(offset);
+  }
+}

--- a/apps/api/src/modules/moderation/dto/moderation.dto.ts
+++ b/apps/api/src/modules/moderation/dto/moderation.dto.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const UsernameParamsSchema = z.object({
+  username: z.string().trim().min(1),
+});
+
+export type UsernameParams = z.input<typeof UsernameParamsSchema>;

--- a/apps/api/src/modules/moderation/moderation.controller.ts
+++ b/apps/api/src/modules/moderation/moderation.controller.ts
@@ -1,0 +1,59 @@
+import type { Request, Response } from "express";
+import { sendErrorForStatus } from "../../commons/http/validation-response.helper";
+import { ModerationService } from "./services/moderation.service";
+import type { UsernameParams } from "./dto/moderation.dto";
+
+export class ModerationController {
+  static async block(req: Request<UsernameParams>, res: Response): Promise<void> {
+    const result = await ModerationService.blockUser(req.user.id, req.params.username);
+    if ("error" in result) {
+      sendErrorForStatus(res, result.status, result.error);
+      return;
+    }
+    res.status(200).json(result);
+  }
+
+  static async unblock(req: Request<UsernameParams>, res: Response): Promise<void> {
+    await ModerationService.unblockUser(req.user.id, req.params.username);
+    res.status(200).json({ success: true });
+  }
+
+  static async mute(req: Request<UsernameParams>, res: Response): Promise<void> {
+    const result = await ModerationService.muteUser(req.user.id, req.params.username);
+    if ("error" in result) {
+      sendErrorForStatus(res, result.status, result.error);
+      return;
+    }
+    res.status(200).json(result);
+  }
+
+  static async unmute(req: Request<UsernameParams>, res: Response): Promise<void> {
+    await ModerationService.unmuteUser(req.user.id, req.params.username);
+    res.status(200).json({ success: true });
+  }
+
+  static async getRelationshipState(
+    req: Request<UsernameParams>,
+    res: Response,
+  ): Promise<void> {
+    const result = await ModerationService.getRelationshipState(
+      req.user.id,
+      req.params.username,
+    );
+    if ("error" in result) {
+      sendErrorForStatus(res, result.status, result.error);
+      return;
+    }
+    res.status(200).json(result);
+  }
+
+  static async getBlocked(req: Request, res: Response): Promise<void> {
+    const blocked = await ModerationService.listBlocked(req.user.id);
+    res.status(200).json(blocked);
+  }
+
+  static async getMuted(req: Request, res: Response): Promise<void> {
+    const muted = await ModerationService.listMuted(req.user.id);
+    res.status(200).json(muted);
+  }
+}

--- a/apps/api/src/modules/moderation/moderation.entity.ts
+++ b/apps/api/src/modules/moderation/moderation.entity.ts
@@ -1,0 +1,36 @@
+import { pgTable, text, timestamp, unique, index } from "drizzle-orm/pg-core";
+import { user } from "../../infrastructure/database/auth.entity";
+
+export const userBlocks = pgTable(
+  "user_block",
+  {
+    blockerId: text("blocker_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    blockedId: text("blocked_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    unique("user_blocks_unique").on(table.blockerId, table.blockedId),
+    index("user_blocks_blocked_id_idx").on(table.blockedId),
+  ],
+);
+
+export const userMutes = pgTable(
+  "user_mute",
+  {
+    muterId: text("muter_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    mutedId: text("muted_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    unique("user_mutes_unique").on(table.muterId, table.mutedId),
+    index("user_mutes_muted_id_idx").on(table.mutedId),
+  ],
+);

--- a/apps/api/src/modules/moderation/moderation.routes.ts
+++ b/apps/api/src/modules/moderation/moderation.routes.ts
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import { ModerationController } from "./moderation.controller";
+import { asyncHandler } from "../../commons/utils/asyncHandler";
+import { requireAuth } from "../../commons/middlewares/requireAuth";
+
+const router = Router();
+
+router.use(requireAuth);
+
+router.get("/blocked", asyncHandler(ModerationController.getBlocked));
+router.get("/muted", asyncHandler(ModerationController.getMuted));
+router.get("/state/:username", asyncHandler(ModerationController.getRelationshipState));
+router.post("/block/:username", asyncHandler(ModerationController.block));
+router.delete("/block/:username", asyncHandler(ModerationController.unblock));
+router.post("/mute/:username", asyncHandler(ModerationController.mute));
+router.delete("/mute/:username", asyncHandler(ModerationController.unmute));
+
+export default router;

--- a/apps/api/src/modules/moderation/repositories/moderation.repository.ts
+++ b/apps/api/src/modules/moderation/repositories/moderation.repository.ts
@@ -1,0 +1,111 @@
+import { and, eq, or } from "drizzle-orm";
+import { db } from "../../../infrastructure/database/db";
+import { user } from "../../../infrastructure/database/auth.entity";
+import { profiles } from "../../users/users.entity";
+import { userBlocks, userMutes } from "../moderation.entity";
+
+export class ModerationRepository {
+  static async blockUser(blockerId: string, blockedId: string) {
+    await db.insert(userBlocks).values({ blockerId, blockedId }).onConflictDoNothing();
+  }
+
+  static async unblockUser(blockerId: string, blockedId: string) {
+    await db
+      .delete(userBlocks)
+      .where(and(eq(userBlocks.blockerId, blockerId), eq(userBlocks.blockedId, blockedId)));
+  }
+
+  static async isBlocked(userAId: string, userBId: string): Promise<boolean> {
+    const [row] = await db
+      .select({ blockerId: userBlocks.blockerId })
+      .from(userBlocks)
+      .where(
+        or(
+          and(eq(userBlocks.blockerId, userAId), eq(userBlocks.blockedId, userBId)),
+          and(eq(userBlocks.blockerId, userBId), eq(userBlocks.blockedId, userAId)),
+        ),
+      )
+      .limit(1);
+
+    return row !== undefined;
+  }
+
+  static async getBlockedIds(blockerId: string): Promise<string[]> {
+    const rows = await db
+      .select({ blockedId: userBlocks.blockedId })
+      .from(userBlocks)
+      .where(eq(userBlocks.blockerId, blockerId));
+
+    return rows.map((row) => row.blockedId);
+  }
+
+  static async getBlockedByIds(blockedId: string): Promise<string[]> {
+    const rows = await db
+      .select({ blockerId: userBlocks.blockerId })
+      .from(userBlocks)
+      .where(eq(userBlocks.blockedId, blockedId));
+
+    return rows.map((row) => row.blockerId);
+  }
+
+  static async listBlocked(blockerId: string) {
+    return db
+      .select({
+        id: user.id,
+        username: user.username,
+        displayUsername: user.displayUsername,
+        image: user.image,
+        avatarUrl: profiles.avatarUrl,
+        createdAt: userBlocks.createdAt,
+      })
+      .from(userBlocks)
+      .innerJoin(user, eq(userBlocks.blockedId, user.id))
+      .leftJoin(profiles, eq(user.id, profiles.userId))
+      .where(eq(userBlocks.blockerId, blockerId));
+  }
+
+  static async muteUser(muterId: string, mutedId: string) {
+    await db.insert(userMutes).values({ muterId, mutedId }).onConflictDoNothing();
+  }
+
+  static async unmuteUser(muterId: string, mutedId: string) {
+    await db
+      .delete(userMutes)
+      .where(and(eq(userMutes.muterId, muterId), eq(userMutes.mutedId, mutedId)));
+  }
+
+  static async isMuted(muterId: string, mutedId: string): Promise<boolean> {
+    const [row] = await db
+      .select({ muterId: userMutes.muterId })
+      .from(userMutes)
+      .where(and(eq(userMutes.muterId, muterId), eq(userMutes.mutedId, mutedId)))
+      .limit(1);
+
+    return row !== undefined;
+  }
+
+  static async getMutedIds(muterId: string): Promise<string[]> {
+    const rows = await db
+      .select({ mutedId: userMutes.mutedId })
+      .from(userMutes)
+      .where(eq(userMutes.muterId, muterId));
+
+    return rows.map((row) => row.mutedId);
+  }
+
+  static async listMuted(muterId: string) {
+    return db
+      .select({
+        id: user.id,
+        username: user.username,
+        displayUsername: user.displayUsername,
+        image: user.image,
+        avatarUrl: profiles.avatarUrl,
+        createdAt: userMutes.createdAt,
+      })
+      .from(userMutes)
+      .innerJoin(user, eq(userMutes.mutedId, user.id))
+      .leftJoin(profiles, eq(user.id, profiles.userId))
+      .where(eq(userMutes.muterId, muterId));
+  }
+}

--- a/apps/api/src/modules/moderation/services/moderation.service.ts
+++ b/apps/api/src/modules/moderation/services/moderation.service.ts
@@ -1,0 +1,87 @@
+import { UsersService } from "../../users/users.service";
+import { SocialRepository } from "../../social/repositories/social.repository";
+import { ModerationRepository } from "../repositories/moderation.repository";
+
+type ServiceError = { error: string; status: 400 | 404 };
+
+export class ModerationService {
+  static async blockUser(
+    blockerId: string,
+    targetUsername: string,
+  ): Promise<ServiceError | { success: true }> {
+    const target = await UsersService.findByUsername(targetUsername);
+    if (!target) {
+      return { error: "User not found", status: 404 };
+    }
+    if (target.id === blockerId) {
+      return { error: "Cannot block yourself", status: 400 };
+    }
+
+    await ModerationRepository.blockUser(blockerId, target.id);
+    await Promise.all([
+      SocialRepository.deleteFollow(blockerId, target.id),
+      SocialRepository.deleteFollow(target.id, blockerId),
+    ]);
+
+    return { success: true };
+  }
+
+  static async unblockUser(blockerId: string, targetUsername: string): Promise<void> {
+    const target = await UsersService.findByUsername(targetUsername);
+    if (!target) {
+      return;
+    }
+
+    await ModerationRepository.unblockUser(blockerId, target.id);
+  }
+
+  static async muteUser(
+    muterId: string,
+    targetUsername: string,
+  ): Promise<ServiceError | { success: true }> {
+    const target = await UsersService.findByUsername(targetUsername);
+    if (!target) {
+      return { error: "User not found", status: 404 };
+    }
+    if (target.id === muterId) {
+      return { error: "Cannot mute yourself", status: 400 };
+    }
+
+    await ModerationRepository.muteUser(muterId, target.id);
+    return { success: true };
+  }
+
+  static async unmuteUser(muterId: string, targetUsername: string): Promise<void> {
+    const target = await UsersService.findByUsername(targetUsername);
+    if (!target) {
+      return;
+    }
+
+    await ModerationRepository.unmuteUser(muterId, target.id);
+  }
+
+  static async getRelationshipState(
+    viewerId: string,
+    targetUsername: string,
+  ): Promise<ServiceError | { isBlocked: boolean; isMuted: boolean }> {
+    const target = await UsersService.findByUsername(targetUsername);
+    if (!target) {
+      return { error: "User not found", status: 404 };
+    }
+
+    const [isBlocked, isMuted] = await Promise.all([
+      ModerationRepository.isBlocked(viewerId, target.id),
+      ModerationRepository.isMuted(viewerId, target.id),
+    ]);
+
+    return { isBlocked, isMuted };
+  }
+
+  static async listBlocked(userId: string) {
+    return ModerationRepository.listBlocked(userId);
+  }
+
+  static async listMuted(userId: string) {
+    return ModerationRepository.listMuted(userId);
+  }
+}

--- a/apps/api/src/modules/notifications/dto/notifications.dto.ts
+++ b/apps/api/src/modules/notifications/dto/notifications.dto.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const ListNotificationsQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(50).optional(),
+  cursor: z.string().optional(),
+});
+
+export type ListNotificationsQuery = z.input<typeof ListNotificationsQuerySchema>;
+
+export const NotificationParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export type NotificationParams = z.input<typeof NotificationParamsSchema>;

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -1,0 +1,50 @@
+import type { Request, Response } from "express";
+import { sendValidationError } from "../../commons/http/validation-response.helper";
+import { NotificationsService } from "./notifications.service";
+import {
+  ListNotificationsQuerySchema,
+  NotificationParamsSchema,
+  type ListNotificationsQuery,
+  type NotificationParams,
+} from "./dto/notifications.dto";
+
+export class NotificationsController {
+  static async list(
+    req: Request<{}, {}, {}, ListNotificationsQuery>,
+    res: Response,
+  ): Promise<void> {
+    const parsed = ListNotificationsQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      sendValidationError(res, parsed.error);
+      return;
+    }
+
+    const page = await NotificationsService.listForUser(
+      req.user.id,
+      parsed.data.limit,
+      parsed.data.cursor,
+    );
+    res.status(200).json(page);
+  }
+
+  static async getUnreadCount(req: Request, res: Response): Promise<void> {
+    const count = await NotificationsService.getUnreadCount(req.user.id);
+    res.status(200).json({ count });
+  }
+
+  static async markRead(req: Request<NotificationParams>, res: Response): Promise<void> {
+    const parsed = NotificationParamsSchema.safeParse(req.params);
+    if (!parsed.success) {
+      sendValidationError(res, parsed.error);
+      return;
+    }
+
+    await NotificationsService.markAsRead(req.user.id, parsed.data.id);
+    res.status(200).json({ success: true });
+  }
+
+  static async markAllRead(req: Request, res: Response): Promise<void> {
+    await NotificationsService.markAllAsRead(req.user.id);
+    res.status(200).json({ success: true });
+  }
+}

--- a/apps/api/src/modules/notifications/notifications.entity.ts
+++ b/apps/api/src/modules/notifications/notifications.entity.ts
@@ -1,0 +1,43 @@
+import {
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+  boolean,
+  index,
+  pgEnum,
+} from "drizzle-orm/pg-core";
+import { user } from "../../infrastructure/database/auth.entity";
+
+export const notificationTypeEnum = pgEnum("notification_type", [
+  "follow",
+  "like_review",
+  "like_post",
+  "like_activity",
+  "comment_review",
+  "comment_post",
+]);
+
+export const notifications = pgTable(
+  "notification",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    recipientId: text("recipient_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    actorId: text("actor_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    type: notificationTypeEnum("type").notNull(),
+    entityId: text("entity_id").notNull(),
+    metadata: text("metadata"), // JSON string
+    isRead: boolean("is_read").default(false).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("notification_recipient_created_idx").on(table.recipientId, table.createdAt),
+    index("notification_recipient_unread_idx").on(table.recipientId, table.isRead),
+  ],
+);

--- a/apps/api/src/modules/notifications/notifications.routes.ts
+++ b/apps/api/src/modules/notifications/notifications.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import { NotificationsController } from "./notifications.controller";
+import { asyncHandler } from "../../commons/utils/asyncHandler";
+import { requireAuth } from "../../commons/middlewares/requireAuth";
+
+const router = Router();
+
+router.use(requireAuth);
+
+router.get("/", asyncHandler(NotificationsController.list));
+router.get("/unread-count", asyncHandler(NotificationsController.getUnreadCount));
+router.post("/read-all", asyncHandler(NotificationsController.markAllRead));
+router.post("/:id/read", asyncHandler(NotificationsController.markRead));
+
+export default router;

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -1,0 +1,73 @@
+import {
+  decodeFeedCursor,
+  encodeFeedCursor,
+} from "../social/helpers/social-feed-cursor.helper";
+import {
+  NotificationsRepository,
+  type NotificationType,
+} from "./repositories/notifications.repository";
+
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 50;
+
+const normalizeLimit = (limit?: number): number => {
+  if (!limit || Number.isNaN(limit)) {
+    return DEFAULT_PAGE_SIZE;
+  }
+  return Math.max(1, Math.min(limit, MAX_PAGE_SIZE));
+};
+
+export type NotificationPage = Awaited<ReturnType<typeof NotificationsService.listForUser>>;
+
+export class NotificationsService {
+  static async notify(input: {
+    recipientId: string;
+    actorId: string;
+    type: NotificationType;
+    entityId: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<void> {
+    if (input.recipientId === input.actorId) {
+      return;
+    }
+
+    await NotificationsRepository.insert({
+      recipientId: input.recipientId,
+      actorId: input.actorId,
+      type: input.type,
+      entityId: input.entityId,
+      metadata: input.metadata ? JSON.stringify(input.metadata) : undefined,
+    });
+  }
+
+  static async listForUser(userId: string, limit?: number, cursor?: string) {
+    const normalizedLimit = normalizeLimit(limit);
+    const decodedCursor = decodeFeedCursor(cursor);
+
+    const rows = await NotificationsRepository.listForUser(
+      userId,
+      normalizedLimit,
+      decodedCursor,
+    );
+
+    const lastRow = rows.at(-1);
+    const nextCursor =
+      rows.length === normalizedLimit && lastRow
+        ? encodeFeedCursor({ createdAt: lastRow.createdAt, id: lastRow.id })
+        : null;
+
+    return { items: rows, nextCursor };
+  }
+
+  static async getUnreadCount(userId: string): Promise<number> {
+    return NotificationsRepository.countUnread(userId);
+  }
+
+  static async markAsRead(userId: string, notificationId: string): Promise<void> {
+    await NotificationsRepository.markRead(userId, notificationId);
+  }
+
+  static async markAllAsRead(userId: string): Promise<void> {
+    await NotificationsRepository.markAllRead(userId);
+  }
+}

--- a/apps/api/src/modules/notifications/repositories/notifications.repository.ts
+++ b/apps/api/src/modules/notifications/repositories/notifications.repository.ts
@@ -1,0 +1,79 @@
+import { and, desc, eq, lt, or, sql } from "drizzle-orm";
+import { db } from "../../../infrastructure/database/db";
+import { user } from "../../../infrastructure/database/auth.entity";
+import { profiles } from "../../users/users.entity";
+import { notifications, type notificationTypeEnum } from "../notifications.entity";
+import type { FeedCursor } from "../../social/helpers/social-feed-cursor.helper";
+
+export type NotificationType = (typeof notificationTypeEnum.enumValues)[number];
+
+export class NotificationsRepository {
+  static async insert(input: {
+    recipientId: string;
+    actorId: string;
+    type: NotificationType;
+    entityId: string;
+    metadata?: string;
+  }) {
+    await db.insert(notifications).values(input);
+  }
+
+  static async listForUser(recipientId: string, limit: number, before?: FeedCursor) {
+    const cursorCondition = before
+      ? or(
+          lt(notifications.createdAt, before.createdAt),
+          and(eq(notifications.createdAt, before.createdAt), lt(notifications.id, before.id)),
+        )
+      : undefined;
+
+    return db
+      .select({
+        id: notifications.id,
+        actorId: notifications.actorId,
+        actorUsername: user.username,
+        actorDisplayUsername: user.displayUsername,
+        actorImage: user.image,
+        actorAvatarUrl: profiles.avatarUrl,
+        type: notifications.type,
+        entityId: notifications.entityId,
+        metadata: notifications.metadata,
+        isRead: notifications.isRead,
+        createdAt: notifications.createdAt,
+      })
+      .from(notifications)
+      .innerJoin(user, eq(notifications.actorId, user.id))
+      .leftJoin(profiles, eq(user.id, profiles.userId))
+      .where(
+        cursorCondition
+          ? and(eq(notifications.recipientId, recipientId), cursorCondition)
+          : eq(notifications.recipientId, recipientId),
+      )
+      .orderBy(desc(notifications.createdAt), desc(notifications.id))
+      .limit(limit);
+  }
+
+  static async countUnread(recipientId: string): Promise<number> {
+    const [row] = await db
+      .select({ count: sql<number>`count(*)`.mapWith(Number) })
+      .from(notifications)
+      .where(and(eq(notifications.recipientId, recipientId), eq(notifications.isRead, false)));
+
+    return row?.count ?? 0;
+  }
+
+  static async markRead(recipientId: string, notificationId: string): Promise<void> {
+    await db
+      .update(notifications)
+      .set({ isRead: true })
+      .where(
+        and(eq(notifications.id, notificationId), eq(notifications.recipientId, recipientId)),
+      );
+  }
+
+  static async markAllRead(recipientId: string): Promise<void> {
+    await db
+      .update(notifications)
+      .set({ isRead: true })
+      .where(and(eq(notifications.recipientId, recipientId), eq(notifications.isRead, false)));
+  }
+}

--- a/apps/api/src/modules/posts/posts.service.ts
+++ b/apps/api/src/modules/posts/posts.service.ts
@@ -24,6 +24,10 @@ export class PostsService {
     return PostsCoreService.delete(postId, userId);
   }
 
+  static async deleteById(postId: string) {
+    return PostsCoreService.deleteById(postId);
+  }
+
   static async like(userId: string, postId: string) {
     return PostsLikesService.like(userId, postId);
   }

--- a/apps/api/src/modules/posts/repositories/posts.repository.ts
+++ b/apps/api/src/modules/posts/repositories/posts.repository.ts
@@ -82,6 +82,13 @@ export class PostsRepository {
     return deleted ?? null;
   }
 
+  // No ownership check — admin moderation only.
+  static async deleteById(postId: string) {
+    const [deleted] = await db.delete(posts).where(eq(posts.id, postId)).returning({ id: posts.id });
+
+    return deleted ?? null;
+  }
+
   static async updateByIdAndUser(postId: string, userId: string, content: string) {
     const [updated] = await db
       .update(posts)

--- a/apps/api/src/modules/posts/repositories/posts.repository.ts
+++ b/apps/api/src/modules/posts/repositories/posts.repository.ts
@@ -28,6 +28,7 @@ export class PostsRepository {
     const [post] = await db
       .select({
         id: posts.id,
+        userId: posts.userId,
         content: posts.content,
         mediaId: posts.mediaId,
         mediaType: posts.mediaType,
@@ -142,6 +143,7 @@ export class PostsRepository {
     const [post] = await db
       .select({
         id: posts.id,
+        userId: posts.userId,
         content: posts.content,
         mediaId: posts.mediaId,
         mediaType: posts.mediaType,

--- a/apps/api/src/modules/posts/services/posts-comments.service.ts
+++ b/apps/api/src/modules/posts/services/posts-comments.service.ts
@@ -2,6 +2,7 @@ import { db } from "../../../infrastructure/database/db";
 import { activities } from "../../social/social.entity";
 import { buildPostCommentedActivityMetadata } from "../helpers/posts-activity.helper";
 import { PostsRepository } from "../repositories/posts.repository";
+import { NotificationsService } from "../../notifications/notifications.service";
 
 export class PostsCommentsService {
   static async getComments(postId: string) {
@@ -17,18 +18,26 @@ export class PostsCommentsService {
     const comment = await PostsRepository.insertComment(userId, postId, content);
 
     if (comment) {
-      await db.insert(activities).values({
-        userId,
-        type: "commented",
-        entityId: comment.id,
-        metadata: JSON.stringify(
-          buildPostCommentedActivityMetadata({
-            post,
-            commentId: comment.id,
-            commentContent: content,
-          }),
-        ),
-      });
+      await Promise.all([
+        db.insert(activities).values({
+          userId,
+          type: "commented",
+          entityId: comment.id,
+          metadata: JSON.stringify(
+            buildPostCommentedActivityMetadata({
+              post,
+              commentId: comment.id,
+              commentContent: content,
+            }),
+          ),
+        }),
+        NotificationsService.notify({
+          recipientId: post.userId,
+          actorId: userId,
+          type: "comment_post",
+          entityId: postId,
+        }),
+      ]);
     }
 
     return comment;

--- a/apps/api/src/modules/posts/services/posts-core.service.ts
+++ b/apps/api/src/modules/posts/services/posts-core.service.ts
@@ -61,6 +61,10 @@ export class PostsCoreService {
     return PostsRepository.deleteByIdAndUser(postId, userId);
   }
 
+  static async deleteById(postId: string) {
+    return PostsRepository.deleteById(postId);
+  }
+
   static async update(postId: string, userId: string, input: UpdatePostDto) {
     return PostsRepository.updateByIdAndUser(postId, userId, input.content);
   }

--- a/apps/api/src/modules/posts/services/posts-likes.service.ts
+++ b/apps/api/src/modules/posts/services/posts-likes.service.ts
@@ -2,6 +2,7 @@ import { db } from "../../../infrastructure/database/db";
 import { activities } from "../../social/social.entity";
 import { buildPostLikedActivityMetadata } from "../helpers/posts-activity.helper";
 import { PostsRepository } from "../repositories/posts.repository";
+import { NotificationsService } from "../../notifications/notifications.service";
 
 export class PostsLikesService {
   static async like(userId: string, postId: string) {
@@ -11,16 +12,24 @@ export class PostsLikesService {
       const postMetadata = await PostsRepository.getPostFeedMetadata(postId);
 
       if (postMetadata) {
-        await db.insert(activities).values({
-          userId,
-          type: "commented",
-          entityId: postId,
-          metadata: JSON.stringify(
-            buildPostLikedActivityMetadata({
-              post: postMetadata,
-            }),
-          ),
-        });
+        await Promise.all([
+          db.insert(activities).values({
+            userId,
+            type: "commented",
+            entityId: postId,
+            metadata: JSON.stringify(
+              buildPostLikedActivityMetadata({
+                post: postMetadata,
+              }),
+            ),
+          }),
+          NotificationsService.notify({
+            recipientId: postMetadata.userId,
+            actorId: userId,
+            type: "like_post",
+            entityId: postId,
+          }),
+        ]);
       }
     }
 

--- a/apps/api/src/modules/reports/dto/reports.dto.ts
+++ b/apps/api/src/modules/reports/dto/reports.dto.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const SubmitReportSchema = z.object({
+  targetType: z.enum(["review", "post"]),
+  targetId: z.string().min(1),
+  reason: z.enum(["spam", "harassment", "inappropriate", "other"]),
+  details: z.string().trim().max(1000).optional(),
+});
+
+export type SubmitReportDto = z.infer<typeof SubmitReportSchema>;
+
+export const ListReportsQuerySchema = z.object({
+  status: z.enum(["pending", "resolved", "dismissed"]).optional(),
+  limit: z.coerce.number().int().positive().max(100).optional(),
+  offset: z.coerce.number().int().nonnegative().optional(),
+});
+
+export type ListReportsQuery = z.input<typeof ListReportsQuerySchema>;
+
+export const ReportParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export type ReportParams = z.input<typeof ReportParamsSchema>;

--- a/apps/api/src/modules/reports/reports.controller.ts
+++ b/apps/api/src/modules/reports/reports.controller.ts
@@ -1,0 +1,86 @@
+import type { Request, Response } from "express";
+import {
+  sendErrorForStatus,
+  sendValidationError,
+} from "../../commons/http/validation-response.helper";
+import { ReportsService } from "./reports.service";
+import {
+  ListReportsQuerySchema,
+  ReportParamsSchema,
+  SubmitReportSchema,
+  type ListReportsQuery,
+  type ReportParams,
+} from "./dto/reports.dto";
+
+export class ReportsController {
+  static async submit(req: Request, res: Response): Promise<void> {
+    const parsed = SubmitReportSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendValidationError(res, parsed.error);
+      return;
+    }
+
+    const result = await ReportsService.submitReport(
+      req.user.id,
+      parsed.data.targetType,
+      parsed.data.targetId,
+      parsed.data.reason,
+      parsed.data.details,
+    );
+
+    if ("error" in result) {
+      sendErrorForStatus(res, result.status, result.error);
+      return;
+    }
+
+    res.status(201).json(result);
+  }
+
+  static async list(
+    req: Request<{}, {}, {}, ListReportsQuery>,
+    res: Response,
+  ): Promise<void> {
+    const parsed = ListReportsQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      sendValidationError(res, parsed.error);
+      return;
+    }
+
+    const reports = await ReportsService.listReports(
+      parsed.data.status,
+      parsed.data.limit ?? 20,
+      parsed.data.offset ?? 0,
+    );
+    res.status(200).json(reports);
+  }
+
+  static async resolve(req: Request<ReportParams>, res: Response): Promise<void> {
+    const parsed = ReportParamsSchema.safeParse(req.params);
+    if (!parsed.success) {
+      sendValidationError(res, parsed.error);
+      return;
+    }
+
+    const result = await ReportsService.resolveReport(parsed.data.id, req.user.id, "resolved");
+    if ("error" in result) {
+      sendErrorForStatus(res, result.status, result.error);
+      return;
+    }
+    res.status(200).json(result);
+  }
+
+  static async dismiss(req: Request<ReportParams>, res: Response): Promise<void> {
+    const parsed = ReportParamsSchema.safeParse(req.params);
+    if (!parsed.success) {
+      sendValidationError(res, parsed.error);
+      return;
+    }
+
+    const result = await ReportsService.resolveReport(parsed.data.id, req.user.id, "dismissed");
+    if ("error" in result) {
+      sendErrorForStatus(res, result.status, result.error);
+      return;
+    }
+    res.status(200).json(result);
+  }
+}

--- a/apps/api/src/modules/reports/reports.controller.ts
+++ b/apps/api/src/modules/reports/reports.controller.ts
@@ -83,4 +83,19 @@ export class ReportsController {
     }
     res.status(200).json(result);
   }
+
+  static async removeContent(req: Request<ReportParams>, res: Response): Promise<void> {
+    const parsed = ReportParamsSchema.safeParse(req.params);
+    if (!parsed.success) {
+      sendValidationError(res, parsed.error);
+      return;
+    }
+
+    const result = await ReportsService.removeContent(parsed.data.id, req.user.id);
+    if ("error" in result) {
+      sendErrorForStatus(res, result.status, result.error);
+      return;
+    }
+    res.status(200).json(result);
+  }
 }

--- a/apps/api/src/modules/reports/reports.entity.ts
+++ b/apps/api/src/modules/reports/reports.entity.ts
@@ -1,0 +1,56 @@
+import {
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+  unique,
+  index,
+  pgEnum,
+} from "drizzle-orm/pg-core";
+import { user } from "../../infrastructure/database/auth.entity";
+
+export const reportTargetTypeEnum = pgEnum("report_target_type", ["review", "post"]);
+
+export const reportReasonEnum = pgEnum("report_reason", [
+  "spam",
+  "harassment",
+  "inappropriate",
+  "other",
+]);
+
+export const reportStatusEnum = pgEnum("report_status", [
+  "pending",
+  "resolved",
+  "dismissed",
+]);
+
+export const reports = pgTable(
+  "report",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    reporterId: text("reporter_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    targetType: reportTargetTypeEnum("target_type").notNull(),
+    targetId: text("target_id").notNull(),
+    // Content snapshot at submit time, so a report stays reviewable even if
+    // the underlying review/post is later edited or deleted.
+    contentSnapshot: text("content_snapshot").notNull(),
+    reason: reportReasonEnum("reason").notNull(),
+    details: text("details"),
+    status: reportStatusEnum("status").default("pending").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    resolvedAt: timestamp("resolved_at"),
+    resolvedBy: text("resolved_by").references(() => user.id, { onDelete: "set null" }),
+  },
+  (table) => [
+    unique("reports_reporter_target_unique").on(
+      table.reporterId,
+      table.targetType,
+      table.targetId,
+    ),
+    index("reports_status_created_idx").on(table.status, table.createdAt),
+  ],
+);

--- a/apps/api/src/modules/reports/reports.routes.ts
+++ b/apps/api/src/modules/reports/reports.routes.ts
@@ -1,0 +1,16 @@
+import { Router } from "express";
+import { ReportsController } from "./reports.controller";
+import { asyncHandler } from "../../commons/utils/asyncHandler";
+import { requireAuth } from "../../commons/middlewares/requireAuth";
+import { requireAdmin } from "../../commons/middlewares/requireAdmin";
+
+const router = Router();
+
+router.use(requireAuth);
+
+router.post("/", asyncHandler(ReportsController.submit));
+router.get("/", requireAdmin, asyncHandler(ReportsController.list));
+router.post("/:id/resolve", requireAdmin, asyncHandler(ReportsController.resolve));
+router.post("/:id/dismiss", requireAdmin, asyncHandler(ReportsController.dismiss));
+
+export default router;

--- a/apps/api/src/modules/reports/reports.routes.ts
+++ b/apps/api/src/modules/reports/reports.routes.ts
@@ -12,5 +12,10 @@ router.post("/", asyncHandler(ReportsController.submit));
 router.get("/", requireAdmin, asyncHandler(ReportsController.list));
 router.post("/:id/resolve", requireAdmin, asyncHandler(ReportsController.resolve));
 router.post("/:id/dismiss", requireAdmin, asyncHandler(ReportsController.dismiss));
+router.post(
+  "/:id/remove-content",
+  requireAdmin,
+  asyncHandler(ReportsController.removeContent),
+);
 
 export default router;

--- a/apps/api/src/modules/reports/reports.service.ts
+++ b/apps/api/src/modules/reports/reports.service.ts
@@ -55,4 +55,23 @@ export class ReportsService {
     await ReportsRepository.updateStatus(reportId, status, adminUserId);
     return { success: true };
   }
+
+  static async removeContent(
+    reportId: string,
+    adminUserId: string,
+  ): Promise<{ error: string; status: 404 } | { success: true }> {
+    const report = await ReportsRepository.findById(reportId);
+    if (!report) {
+      return { error: "Report not found", status: 404 };
+    }
+
+    if (report.targetType === "review") {
+      await ReviewsService.deleteById(report.targetId);
+    } else {
+      await PostsService.deleteById(report.targetId);
+    }
+
+    await ReportsRepository.updateStatus(reportId, "resolved", adminUserId);
+    return { success: true };
+  }
 }

--- a/apps/api/src/modules/reports/reports.service.ts
+++ b/apps/api/src/modules/reports/reports.service.ts
@@ -1,0 +1,58 @@
+import { ReviewsService } from "../reviews/reviews.service";
+import { PostsService } from "../posts/posts.service";
+import {
+  ReportsRepository,
+  type ReportReason,
+  type ReportStatus,
+  type ReportTargetType,
+} from "./repositories/reports.repository";
+
+const CONTENT_SNAPSHOT_MAX_LENGTH = 2000;
+
+export class ReportsService {
+  static async submitReport(
+    reporterId: string,
+    targetType: ReportTargetType,
+    targetId: string,
+    reason: ReportReason,
+    details?: string,
+  ): Promise<{ error: string; status: 404 } | { success: true }> {
+    const content =
+      targetType === "review"
+        ? (await ReviewsService.findById(targetId))?.review.content
+        : (await PostsService.findById(targetId))?.content;
+
+    if (content === undefined) {
+      return { error: `${targetType === "review" ? "Review" : "Post"} not found`, status: 404 };
+    }
+
+    await ReportsRepository.insert({
+      reporterId,
+      targetType,
+      targetId,
+      contentSnapshot: content.slice(0, CONTENT_SNAPSHOT_MAX_LENGTH),
+      reason,
+      details: details && details.length > 0 ? details : undefined,
+    });
+
+    return { success: true };
+  }
+
+  static async listReports(status: ReportStatus | undefined, limit: number, offset: number) {
+    return ReportsRepository.list(status, limit, offset);
+  }
+
+  static async resolveReport(
+    reportId: string,
+    adminUserId: string,
+    status: "resolved" | "dismissed",
+  ): Promise<{ error: string; status: 404 } | { success: true }> {
+    const report = await ReportsRepository.findById(reportId);
+    if (!report) {
+      return { error: "Report not found", status: 404 };
+    }
+
+    await ReportsRepository.updateStatus(reportId, status, adminUserId);
+    return { success: true };
+  }
+}

--- a/apps/api/src/modules/reports/repositories/reports.repository.ts
+++ b/apps/api/src/modules/reports/repositories/reports.repository.ts
@@ -1,0 +1,71 @@
+import { and, desc, eq } from "drizzle-orm";
+import { db } from "../../../infrastructure/database/db";
+import { user } from "../../../infrastructure/database/auth.entity";
+import {
+  reports,
+  type reportReasonEnum,
+  type reportStatusEnum,
+  type reportTargetTypeEnum,
+} from "../reports.entity";
+
+export type ReportTargetType = (typeof reportTargetTypeEnum.enumValues)[number];
+export type ReportReason = (typeof reportReasonEnum.enumValues)[number];
+export type ReportStatus = (typeof reportStatusEnum.enumValues)[number];
+
+export class ReportsRepository {
+  static async insert(input: {
+    reporterId: string;
+    targetType: ReportTargetType;
+    targetId: string;
+    contentSnapshot: string;
+    reason: ReportReason;
+    details?: string;
+  }) {
+    const [row] = await db
+      .insert(reports)
+      .values(input)
+      .onConflictDoNothing()
+      .returning();
+
+    return row ?? null;
+  }
+
+  static async list(status: ReportStatus | undefined, limit: number, offset: number) {
+    return db
+      .select({
+        id: reports.id,
+        reporterId: reports.reporterId,
+        reporterUsername: user.username,
+        targetType: reports.targetType,
+        targetId: reports.targetId,
+        contentSnapshot: reports.contentSnapshot,
+        reason: reports.reason,
+        details: reports.details,
+        status: reports.status,
+        createdAt: reports.createdAt,
+        resolvedAt: reports.resolvedAt,
+      })
+      .from(reports)
+      .innerJoin(user, eq(reports.reporterId, user.id))
+      .where(status ? eq(reports.status, status) : undefined)
+      .orderBy(desc(reports.createdAt))
+      .limit(limit)
+      .offset(offset);
+  }
+
+  static async findById(reportId: string) {
+    const [row] = await db.select().from(reports).where(eq(reports.id, reportId)).limit(1);
+    return row ?? null;
+  }
+
+  static async updateStatus(
+    reportId: string,
+    status: "resolved" | "dismissed",
+    resolvedBy: string,
+  ) {
+    await db
+      .update(reports)
+      .set({ status, resolvedAt: new Date(), resolvedBy })
+      .where(and(eq(reports.id, reportId), eq(reports.status, "pending")));
+  }
+}

--- a/apps/api/src/modules/reviews/reviews.service.ts
+++ b/apps/api/src/modules/reviews/reviews.service.ts
@@ -28,6 +28,10 @@ export class ReviewsService {
     return ReviewsCoreService.delete(reviewId, userId);
   }
 
+  static async deleteById(reviewId: string) {
+    return ReviewsCoreService.deleteById(reviewId);
+  }
+
   static async getComments(reviewId: string) {
     return ReviewsCommentsService.getComments(reviewId);
   }

--- a/apps/api/src/modules/reviews/services/reviews-comments.service.ts
+++ b/apps/api/src/modules/reviews/services/reviews-comments.service.ts
@@ -3,6 +3,7 @@ import { activities } from "../../social/social.entity";
 import { comments } from "../reviews.entity";
 import { buildCommentCreatedActivityMetadata } from "../helpers/reviews-activity.helper";
 import { ReviewsRepository } from "../repositories/reviews.repository";
+import { NotificationsService } from "../../notifications/notifications.service";
 
 export class ReviewsCommentsService {
   static async getComments(reviewId: string) {
@@ -53,6 +54,12 @@ export class ReviewsCommentsService {
         ),
       }),
       ReviewsRepository.getCommentWithAuthorById(comment.id),
+      NotificationsService.notify({
+        recipientId: review.userId,
+        actorId: userId,
+        type: "comment_review",
+        entityId: reviewId,
+      }),
     ]);
 
     if (!commentWithAuthor) {

--- a/apps/api/src/modules/reviews/services/reviews-core.service.ts
+++ b/apps/api/src/modules/reviews/services/reviews-core.service.ts
@@ -160,4 +160,14 @@ export class ReviewsCoreService {
 
     return deleted ?? null;
   }
+
+  // No ownership check — admin moderation only.
+  static async deleteById(reviewId: string) {
+    const [deleted] = await db
+      .delete(reviews)
+      .where(eq(reviews.id, reviewId))
+      .returning({ id: reviews.id });
+
+    return deleted ?? null;
+  }
 }

--- a/apps/api/src/modules/reviews/services/reviews-likes.service.ts
+++ b/apps/api/src/modules/reviews/services/reviews-likes.service.ts
@@ -4,6 +4,7 @@ import { activities } from "../../social/social.entity";
 import { buildReviewLikedActivityMetadata } from "../helpers/reviews-activity.helper";
 import { ReviewsRepository } from "../repositories/reviews.repository";
 import { reviewLikes } from "../reviews.entity";
+import { NotificationsService } from "../../notifications/notifications.service";
 
 export class ReviewsLikesService {
   static async likeReview(userId: string, reviewId: string) {
@@ -27,26 +28,36 @@ export class ReviewsLikesService {
         ? review.mediaType
         : null;
 
-    await db.insert(activities).values({
-      userId,
-      type: "liked_review",
-      entityId: reviewId,
-      metadata: JSON.stringify(
-        buildReviewLikedActivityMetadata({
-          reviewId,
-          mediaMetadata: review && activityMediaType
-            ? {
-                mediaType: activityMediaType,
-                tmdbId: review.tmdbId,
-                title: review.title,
-                posterPath: review.posterPath,
-                releaseYear: review.releaseYear,
-              }
-            : null,
-          targetUsername: review?.reviewAuthorUsername ?? null,
-        }),
-      ),
-    });
+    await Promise.all([
+      db.insert(activities).values({
+        userId,
+        type: "liked_review",
+        entityId: reviewId,
+        metadata: JSON.stringify(
+          buildReviewLikedActivityMetadata({
+            reviewId,
+            mediaMetadata: review && activityMediaType
+              ? {
+                  mediaType: activityMediaType,
+                  tmdbId: review.tmdbId,
+                  title: review.title,
+                  posterPath: review.posterPath,
+                  releaseYear: review.releaseYear,
+                }
+              : null,
+            targetUsername: review?.reviewAuthorUsername ?? null,
+          }),
+        ),
+      }),
+      review
+        ? NotificationsService.notify({
+            recipientId: review.userId,
+            actorId: userId,
+            type: "like_review",
+            entityId: reviewId,
+          })
+        : Promise.resolve(),
+    ]);
 
     return { liked: true, alreadyLiked: false };
   }

--- a/apps/api/src/modules/search/dto/search.dto.ts
+++ b/apps/api/src/modules/search/dto/search.dto.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const SearchQuerySchema = z.object({
+  query: z.string().trim().min(1),
+});
+
+export type SearchQuery = z.input<typeof SearchQuerySchema>;

--- a/apps/api/src/modules/search/search.controller.ts
+++ b/apps/api/src/modules/search/search.controller.ts
@@ -1,0 +1,20 @@
+import type { Request, Response } from "express";
+import { sendValidationError } from "../../commons/http/validation-response.helper";
+import { SearchService } from "./search.service";
+import { SearchQuerySchema, type SearchQuery } from "./dto/search.dto";
+
+export class SearchController {
+  static async searchTitles(
+    req: Request<{}, {}, {}, SearchQuery>,
+    res: Response,
+  ): Promise<void> {
+    const parsed = SearchQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      sendValidationError(res, parsed.error);
+      return;
+    }
+
+    const results = await SearchService.searchTitles(parsed.data.query);
+    res.status(200).json(results);
+  }
+}

--- a/apps/api/src/modules/search/search.routes.ts
+++ b/apps/api/src/modules/search/search.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { SearchController } from "./search.controller";
+import { asyncHandler } from "../../commons/utils/asyncHandler";
+
+const router = Router();
+
+router.get("/", asyncHandler(SearchController.searchTitles));
+
+export default router;

--- a/apps/api/src/modules/search/search.service.ts
+++ b/apps/api/src/modules/search/search.service.ts
@@ -1,0 +1,44 @@
+import { MoviesService } from "../movies/movies.service";
+import { SerialsService } from "../serials/serials.service";
+
+const MAX_RESULTS = 20;
+
+export type UnifiedSearchResult = {
+  mediaType: "movie" | "tv";
+  tmdbId: number;
+  title: string;
+  posterPath: string | null;
+  releaseDate: string | null;
+  popularity: number;
+};
+
+export class SearchService {
+  static async searchTitles(query: string): Promise<UnifiedSearchResult[]> {
+    const [movies, series] = await Promise.all([
+      MoviesService.search(query),
+      SerialsService.search(query),
+    ]);
+
+    const movieResults: UnifiedSearchResult[] = movies.map((movie) => ({
+      mediaType: "movie",
+      tmdbId: movie.id,
+      title: movie.title,
+      posterPath: movie.poster_path,
+      releaseDate: movie.release_date || null,
+      popularity: movie.popularity,
+    }));
+
+    const seriesResults: UnifiedSearchResult[] = series.map((show) => ({
+      mediaType: "tv",
+      tmdbId: show.id,
+      title: show.name,
+      posterPath: show.poster_path,
+      releaseDate: show.first_air_date,
+      popularity: show.popularity,
+    }));
+
+    return [...movieResults, ...seriesResults]
+      .sort((a, b) => b.popularity - a.popularity)
+      .slice(0, MAX_RESULTS);
+  }
+}

--- a/apps/api/src/modules/social/services/social-feed.service.ts
+++ b/apps/api/src/modules/social/services/social-feed.service.ts
@@ -10,6 +10,7 @@ import { dedupeReviewFeedItems } from "../helpers/social-feed-dedupe.helper";
 import { toFeedItem } from "../helpers/social-feed-item.helper";
 import { decodeFeedCursor, encodeFeedCursor } from "../helpers/social-feed-cursor.helper";
 import { SocialRepository } from "../repositories/social.repository";
+import { ModerationRepository } from "../../moderation/repositories/moderation.repository";
 import type { ActivityRow, FeedItem } from "../types/social-feed.types";
 
 export type FeedPage = {
@@ -54,8 +55,24 @@ const getFollowingFeedUncached = async (
   const fetchLimit = normalizedLimit * 2;
   const decodedCursor = decodeFeedCursor(cursor);
 
-  const followingRows = await SocialRepository.getFollowingIdsByFollowerId(userId);
-  const feedUserIds = [...new Set([userId, ...followingRows.map((row) => row.followingId)])];
+  const [followingRows, blockedIds, blockedByIds, mutedIds] = await Promise.all([
+    SocialRepository.getFollowingIdsByFollowerId(userId),
+    ModerationRepository.getBlockedIds(userId),
+    ModerationRepository.getBlockedByIds(userId),
+    ModerationRepository.getMutedIds(userId),
+  ]);
+  // Blocks are mutual (either direction hides the other's activity); mutes
+  // are one-directional — being muted by someone else must not hide your
+  // own activity from your own feed.
+  const excludedIds = new Set([...blockedIds, ...blockedByIds, ...mutedIds]);
+  const feedUserIds = [
+    userId,
+    ...new Set(
+      followingRows
+        .map((row) => row.followingId)
+        .filter((followingId) => !excludedIds.has(followingId)),
+    ),
+  ];
 
   const rows = await SocialRepository.getFeedActivityRows(feedUserIds, fetchLimit, decodedCursor);
   const items = await buildFeedItems(rows, userId);

--- a/apps/api/src/modules/social/services/social-follow.service.ts
+++ b/apps/api/src/modules/social/services/social-follow.service.ts
@@ -1,4 +1,5 @@
 import { SocialRepository } from "../repositories/social.repository";
+import { ModerationRepository } from "../../moderation/repositories/moderation.repository";
 
 export class SocialFollowService {
   static async follow(
@@ -8,6 +9,10 @@ export class SocialFollowService {
   ): Promise<{ error: string } | { success: true }> {
     if (followerId === followingId) {
       return { error: "Cannot follow yourself" } as const;
+    }
+
+    if (await ModerationRepository.isBlocked(followerId, followingId)) {
+      return { error: "Cannot follow this user" } as const;
     }
 
     const row = await SocialRepository.insertFollow(followerId, followingId);

--- a/apps/api/src/modules/social/services/social-follow.service.ts
+++ b/apps/api/src/modules/social/services/social-follow.service.ts
@@ -1,5 +1,6 @@
 import { SocialRepository } from "../repositories/social.repository";
 import { ModerationRepository } from "../../moderation/repositories/moderation.repository";
+import { NotificationsService } from "../../notifications/notifications.service";
 
 export class SocialFollowService {
   static async follow(
@@ -18,15 +19,23 @@ export class SocialFollowService {
     const row = await SocialRepository.insertFollow(followerId, followingId);
 
     if (row) {
-      await SocialRepository.insertActivity({
-        userId: followerId,
-        type: "followed_user",
-        entityId: followingId,
-        metadata: JSON.stringify({
-          followingId,
-          targetUsername: targetUsername ?? null,
+      await Promise.all([
+        SocialRepository.insertActivity({
+          userId: followerId,
+          type: "followed_user",
+          entityId: followingId,
+          metadata: JSON.stringify({
+            followingId,
+            targetUsername: targetUsername ?? null,
+          }),
         }),
-      });
+        NotificationsService.notify({
+          recipientId: followingId,
+          actorId: followerId,
+          type: "follow",
+          entityId: followerId,
+        }),
+      ]);
     }
 
     return { success: true } as const;

--- a/apps/api/src/modules/social/social.service.ts
+++ b/apps/api/src/modules/social/social.service.ts
@@ -1,6 +1,7 @@
 import { SocialFeedService } from "./services/social-feed.service";
 import { SocialFollowService } from "./services/social-follow.service";
 import { SocialRepository } from "./repositories/social.repository";
+import { NotificationsService } from "../notifications/notifications.service";
 
 export type {
   FeedActivityKind,
@@ -58,7 +59,15 @@ export class SocialService {
     if (!activity) {
       return { error: "Activity not found" } as const;
     }
-    await SocialRepository.likeActivity(userId, activityId);
+    await Promise.all([
+      SocialRepository.likeActivity(userId, activityId),
+      NotificationsService.notify({
+        recipientId: activity.userId,
+        actorId: userId,
+        type: "like_activity",
+        entityId: activityId,
+      }),
+    ]);
     return { success: true } as const;
   }
 

--- a/apps/api/tests/integration/admin/admin.test.ts
+++ b/apps/api/tests/integration/admin/admin.test.ts
@@ -1,0 +1,127 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import { signUpTestUser } from "../../support/app/auth-flow";
+import { promoteToAdmin } from "../../support/factories/admin.factory";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+describe("admin", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("requires auth to list users", async () => {
+    const response = await apiRequest(getServer().baseUrl, "/api/admin/users");
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects listing users for a non-admin", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "adma");
+
+    const response = await apiRequest(getServer().baseUrl, "/api/admin/users", {}, jar);
+    expect(response.status).toBe(403);
+  });
+
+  it("lets an admin list and search users", async () => {
+    const admin = await signUpTestUser(getServer().baseUrl, "admb");
+    await promoteToAdmin(admin.username);
+    const target = await signUpTestUser(getServer().baseUrl, "admc");
+
+    const listResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/admin/users",
+      {},
+      admin.jar,
+    );
+    expect(listResponse.status).toBe(200);
+    const users = (await listResponse.json()) as { username: string }[];
+    expect(users.some((u) => u.username === target.username)).toBe(true);
+
+    const searchResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/admin/users?query=${target.username}`,
+      {},
+      admin.jar,
+    );
+    const searched = (await searchResponse.json()) as { username: string }[];
+    expect(searched.map((u) => u.username)).toEqual([target.username]);
+  });
+
+  it("removes reported content and marks the report resolved", async () => {
+    const admin = await signUpTestUser(getServer().baseUrl, "admd");
+    await promoteToAdmin(admin.username);
+    const postAuthor = await signUpTestUser(getServer().baseUrl, "adme");
+    const reporter = await signUpTestUser(getServer().baseUrl, "admf");
+
+    const createPost = await apiRequest(
+      getServer().baseUrl,
+      "/api/posts",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "offensive content" }),
+      },
+      postAuthor.jar,
+    );
+    const post = (await createPost.json()) as { id: string };
+
+    const reportResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/reports",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ targetType: "post", targetId: post.id, reason: "inappropriate" }),
+      },
+      reporter.jar,
+    );
+    expect(reportResponse.status).toBe(201);
+
+    const listResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/reports?status=pending",
+      {},
+      admin.jar,
+    );
+    const list = (await listResponse.json()) as { id: string; targetId: string }[];
+    const report = list.find((item) => item.targetId === post.id);
+    expect(report).toBeDefined();
+
+    const removeResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/reports/${report!.id}/remove-content`,
+      { method: "POST" },
+      admin.jar,
+    );
+    expect(removeResponse.status).toBe(200);
+
+    const postAfterRemoval = await apiRequest(getServer().baseUrl, `/api/posts/${post.id}`);
+    expect(postAfterRemoval.status).toBe(404);
+
+    const listAfterRemoval = await apiRequest(
+      getServer().baseUrl,
+      "/api/reports?status=pending",
+      {},
+      admin.jar,
+    );
+    const pendingAfter = (await listAfterRemoval.json()) as { id: string }[];
+    expect(pendingAfter.find((item) => item.id === report!.id)).toBeUndefined();
+  });
+});

--- a/apps/api/tests/integration/moderation/block-mute.test.ts
+++ b/apps/api/tests/integration/moderation/block-mute.test.ts
@@ -1,0 +1,210 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import { signUpTestUser } from "../../support/app/auth-flow";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+describe("block and mute", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("requires auth to block a user", async () => {
+    const response = await apiRequest(getServer().baseUrl, "/api/moderation/block/nobody", {
+      method: "POST",
+    });
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects blocking yourself", async () => {
+    const { jar, username } = await signUpTestUser(getServer().baseUrl, "self");
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      `/api/moderation/block/${username}`,
+      { method: "POST" },
+      jar,
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("404s when blocking a user that doesn't exist", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "blkr");
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      "/api/moderation/block/does-not-exist",
+      { method: "POST" },
+      jar,
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("blocking severs an existing follow relationship in both directions and prevents re-following", async () => {
+    const a = await signUpTestUser(getServer().baseUrl, "blka");
+    const b = await signUpTestUser(getServer().baseUrl, "blkb");
+
+    // a follows b, b follows a
+    await apiRequest(
+      getServer().baseUrl,
+      `/api/social/follow/${b.username}`,
+      { method: "POST" },
+      a.jar,
+    );
+    await apiRequest(
+      getServer().baseUrl,
+      `/api/social/follow/${a.username}`,
+      { method: "POST" },
+      b.jar,
+    );
+
+    const isFollowingBefore = await apiRequest(
+      getServer().baseUrl,
+      `/api/social/is-following/${b.username}`,
+      {},
+      a.jar,
+    );
+    expect((await isFollowingBefore.json()) as { isFollowing: boolean }).toEqual({
+      isFollowing: true,
+    });
+
+    const blockResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/moderation/block/${b.username}`,
+      { method: "POST" },
+      a.jar,
+    );
+    expect(blockResponse.status).toBe(200);
+
+    const isFollowingAfter = await apiRequest(
+      getServer().baseUrl,
+      `/api/social/is-following/${b.username}`,
+      {},
+      a.jar,
+    );
+    expect((await isFollowingAfter.json()) as { isFollowing: boolean }).toEqual({
+      isFollowing: false,
+    });
+
+    // b can no longer follow a either (blocked in either direction)
+    const reFollow = await apiRequest(
+      getServer().baseUrl,
+      `/api/social/follow/${a.username}`,
+      { method: "POST" },
+      b.jar,
+    );
+    const reFollowBody = (await reFollow.json()) as { error: { message: string } };
+    expect(reFollowBody.error.message).toBe("Cannot follow this user");
+  });
+
+  it("reflects relationship state and unblocks", async () => {
+    const a = await signUpTestUser(getServer().baseUrl, "sta");
+    const b = await signUpTestUser(getServer().baseUrl, "stb");
+
+    await apiRequest(
+      getServer().baseUrl,
+      `/api/moderation/block/${b.username}`,
+      { method: "POST" },
+      a.jar,
+    );
+
+    const stateResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/moderation/state/${b.username}`,
+      {},
+      a.jar,
+    );
+    expect((await stateResponse.json()) as { isBlocked: boolean; isMuted: boolean }).toEqual({
+      isBlocked: true,
+      isMuted: false,
+    });
+
+    const listResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/moderation/blocked",
+      {},
+      a.jar,
+    );
+    const blockedList = (await listResponse.json()) as { username: string }[];
+    expect(blockedList.map((entry) => entry.username)).toContain(b.username);
+
+    const unblockResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/moderation/block/${b.username}`,
+      { method: "DELETE" },
+      a.jar,
+    );
+    expect(unblockResponse.status).toBe(200);
+
+    const stateAfterUnblock = await apiRequest(
+      getServer().baseUrl,
+      `/api/moderation/state/${b.username}`,
+      {},
+      a.jar,
+    );
+    expect(
+      (await stateAfterUnblock.json()) as { isBlocked: boolean; isMuted: boolean },
+    ).toEqual({ isBlocked: false, isMuted: false });
+  });
+
+  it("mutes a user without affecting the follow relationship", async () => {
+    const a = await signUpTestUser(getServer().baseUrl, "mua");
+    const b = await signUpTestUser(getServer().baseUrl, "mub");
+
+    await apiRequest(
+      getServer().baseUrl,
+      `/api/social/follow/${b.username}`,
+      { method: "POST" },
+      a.jar,
+    );
+
+    const muteResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/moderation/mute/${b.username}`,
+      { method: "POST" },
+      a.jar,
+    );
+    expect(muteResponse.status).toBe(200);
+
+    const isFollowingAfterMute = await apiRequest(
+      getServer().baseUrl,
+      `/api/social/is-following/${b.username}`,
+      {},
+      a.jar,
+    );
+    expect(
+      (await isFollowingAfterMute.json()) as { isFollowing: boolean },
+    ).toEqual({ isFollowing: true });
+
+    const mutedList = await apiRequest(getServer().baseUrl, "/api/moderation/muted", {}, a.jar);
+    const mutedNames = ((await mutedList.json()) as { username: string }[]).map(
+      (entry) => entry.username,
+    );
+    expect(mutedNames).toContain(b.username);
+
+    const unmuteResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/moderation/mute/${b.username}`,
+      { method: "DELETE" },
+      a.jar,
+    );
+    expect(unmuteResponse.status).toBe(200);
+  });
+});

--- a/apps/api/tests/integration/notifications/notifications.test.ts
+++ b/apps/api/tests/integration/notifications/notifications.test.ts
@@ -1,0 +1,214 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { apiRequest } from "../../support/app/http-client";
+import { signUpTestUser } from "../../support/app/auth-flow";
+import { seedTestMovie } from "../../support/factories/media.factory";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+
+type NotificationItem = {
+  id: string;
+  actorId: string;
+  type: string;
+  entityId: string;
+  isRead: boolean;
+};
+
+describe("notifications", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("requires auth to list notifications", async () => {
+    const response = await apiRequest(getServer().baseUrl, "/api/notifications");
+    expect(response.status).toBe(401);
+  });
+
+  it("notifies on follow and marks it read", async () => {
+    const a = await signUpTestUser(getServer().baseUrl, "nota");
+    const b = await signUpTestUser(getServer().baseUrl, "notb");
+
+    await apiRequest(
+      getServer().baseUrl,
+      `/api/social/follow/${a.username}`,
+      { method: "POST" },
+      b.jar,
+    );
+
+    const listResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/notifications",
+      {},
+      a.jar,
+    );
+    const page = (await listResponse.json()) as { items: NotificationItem[] };
+    const followNotification = page.items.find((item) => item.type === "follow");
+    expect(followNotification).toBeDefined();
+    expect(followNotification?.isRead).toBe(false);
+
+    const unreadBefore = await apiRequest(
+      getServer().baseUrl,
+      "/api/notifications/unread-count",
+      {},
+      a.jar,
+    );
+    expect((await unreadBefore.json()) as { count: number }).toEqual({ count: 1 });
+
+    const markReadResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/notifications/${followNotification!.id}/read`,
+      { method: "POST" },
+      a.jar,
+    );
+    expect(markReadResponse.status).toBe(200);
+
+    const unreadAfter = await apiRequest(
+      getServer().baseUrl,
+      "/api/notifications/unread-count",
+      {},
+      a.jar,
+    );
+    expect((await unreadAfter.json()) as { count: number }).toEqual({ count: 0 });
+  });
+
+  it("does not notify on self-follow-adjacent actions (liking your own review)", async () => {
+    const owner = await signUpTestUser(getServer().baseUrl, "nsa");
+    const movie = await seedTestMovie();
+
+    const createReview = await apiRequest(
+      getServer().baseUrl,
+      "/api/reviews",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          tmdbId: movie.tmdbId,
+          mediaType: "movie",
+          content: "Great movie",
+        }),
+      },
+      owner.jar,
+    );
+    const review = (await createReview.json()) as { review: { id: string } } | { id: string };
+    const reviewId = "review" in review ? review.review.id : review.id;
+
+    await apiRequest(
+      getServer().baseUrl,
+      `/api/reviews/${reviewId}/like`,
+      { method: "POST" },
+      owner.jar,
+    );
+
+    const listResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/notifications",
+      {},
+      owner.jar,
+    );
+    const page = (await listResponse.json()) as { items: NotificationItem[] };
+    expect(page.items.find((item) => item.type === "like_review")).toBeUndefined();
+  });
+
+  it("notifies the review author when someone else likes and comments", async () => {
+    const author = await signUpTestUser(getServer().baseUrl, "reva");
+    const liker = await signUpTestUser(getServer().baseUrl, "revb");
+    const movie = await seedTestMovie();
+
+    const createReview = await apiRequest(
+      getServer().baseUrl,
+      "/api/reviews",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          tmdbId: movie.tmdbId,
+          mediaType: "movie",
+          content: "Loved it",
+        }),
+      },
+      author.jar,
+    );
+    const review = (await createReview.json()) as { review: { id: string } } | { id: string };
+    const reviewId = "review" in review ? review.review.id : review.id;
+
+    await apiRequest(
+      getServer().baseUrl,
+      `/api/reviews/${reviewId}/like`,
+      { method: "POST" },
+      liker.jar,
+    );
+
+    await apiRequest(
+      getServer().baseUrl,
+      `/api/reviews/${reviewId}/comments`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "Agreed!" }),
+      },
+      liker.jar,
+    );
+
+    const listResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/notifications",
+      {},
+      author.jar,
+    );
+    const page = (await listResponse.json()) as { items: NotificationItem[] };
+    const types = page.items.map((item) => item.type);
+    expect(types).toContain("like_review");
+    expect(types).toContain("comment_review");
+  });
+
+  it("marks all notifications as read", async () => {
+    const a = await signUpTestUser(getServer().baseUrl, "mara");
+    const b = await signUpTestUser(getServer().baseUrl, "marb");
+    const c = await signUpTestUser(getServer().baseUrl, "marc");
+
+    await apiRequest(
+      getServer().baseUrl,
+      `/api/social/follow/${a.username}`,
+      { method: "POST" },
+      b.jar,
+    );
+    await apiRequest(
+      getServer().baseUrl,
+      `/api/social/follow/${a.username}`,
+      { method: "POST" },
+      c.jar,
+    );
+
+    const markAllResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/notifications/read-all",
+      { method: "POST" },
+      a.jar,
+    );
+    expect(markAllResponse.status).toBe(200);
+
+    const unreadAfter = await apiRequest(
+      getServer().baseUrl,
+      "/api/notifications/unread-count",
+      {},
+      a.jar,
+    );
+    expect((await unreadAfter.json()) as { count: number }).toEqual({ count: 0 });
+  });
+});

--- a/apps/api/tests/integration/reports/reports.test.ts
+++ b/apps/api/tests/integration/reports/reports.test.ts
@@ -1,28 +1,11 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { eq } from "drizzle-orm";
 import { apiRequest } from "../../support/app/http-client";
 import { signUpTestUser } from "../../support/app/auth-flow";
+import { promoteToAdmin } from "../../support/factories/admin.factory";
 import {
   startTestServer,
   type RunningTestServer,
 } from "../../support/app/test-server";
-import { db } from "../../../src/infrastructure/database/db";
-import { user as userTable } from "../../../src/infrastructure/database/auth.entity";
-import { profiles } from "../../../src/modules/users/users.entity";
-
-const promoteToAdmin = async (username: string): Promise<void> => {
-  const [row] = await db
-    .select({ id: userTable.id })
-    .from(userTable)
-    .where(eq(userTable.username, username))
-    .limit(1);
-
-  if (!row) {
-    throw new Error(`Test user ${username} not found`);
-  }
-
-  await db.update(profiles).set({ isAdmin: true }).where(eq(profiles.userId, row.id));
-};
 
 describe("reports", () => {
   let testServer: RunningTestServer | null = null;

--- a/apps/api/tests/integration/reports/reports.test.ts
+++ b/apps/api/tests/integration/reports/reports.test.ts
@@ -1,0 +1,159 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { eq } from "drizzle-orm";
+import { apiRequest } from "../../support/app/http-client";
+import { signUpTestUser } from "../../support/app/auth-flow";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../../support/app/test-server";
+import { db } from "../../../src/infrastructure/database/db";
+import { user as userTable } from "../../../src/infrastructure/database/auth.entity";
+import { profiles } from "../../../src/modules/users/users.entity";
+
+const promoteToAdmin = async (username: string): Promise<void> => {
+  const [row] = await db
+    .select({ id: userTable.id })
+    .from(userTable)
+    .where(eq(userTable.username, username))
+    .limit(1);
+
+  if (!row) {
+    throw new Error(`Test user ${username} not found`);
+  }
+
+  await db.update(profiles).set({ isAdmin: true }).where(eq(profiles.userId, row.id));
+};
+
+describe("reports", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("requires auth to submit a report", async () => {
+    const response = await apiRequest(getServer().baseUrl, "/api/reports", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ targetType: "post", targetId: "x", reason: "spam" }),
+    });
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects listing reports for a non-admin", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "repa");
+
+    const response = await apiRequest(getServer().baseUrl, "/api/reports", {}, jar);
+    expect(response.status).toBe(403);
+  });
+
+  it("404s when reporting a post that doesn't exist", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "repb");
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      "/api/reports",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          targetType: "post",
+          targetId: "00000000-0000-0000-0000-000000000000",
+          reason: "spam",
+        }),
+      },
+      jar,
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("submits a report on a post and an admin can resolve it", async () => {
+    const reporter = await signUpTestUser(getServer().baseUrl, "repc");
+    const postAuthor = await signUpTestUser(getServer().baseUrl, "repd");
+    const admin = await signUpTestUser(getServer().baseUrl, "repe");
+    await promoteToAdmin(admin.username);
+
+    const createPost = await apiRequest(
+      getServer().baseUrl,
+      "/api/posts",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "spammy content" }),
+      },
+      postAuthor.jar,
+    );
+    const post = (await createPost.json()) as { id: string };
+
+    const submitResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/reports",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          targetType: "post",
+          targetId: post.id,
+          reason: "spam",
+          details: "This looks like spam",
+        }),
+      },
+      reporter.jar,
+    );
+    expect(submitResponse.status).toBe(201);
+
+    // Resubmitting the same report is idempotent, not a conflict error.
+    const resubmitResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/reports",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ targetType: "post", targetId: post.id, reason: "spam" }),
+      },
+      reporter.jar,
+    );
+    expect(resubmitResponse.status).toBe(201);
+
+    const listResponse = await apiRequest(
+      getServer().baseUrl,
+      "/api/reports?status=pending",
+      {},
+      admin.jar,
+    );
+    expect(listResponse.status).toBe(200);
+    const list = (await listResponse.json()) as { id: string; targetId: string }[];
+    const report = list.find((item) => item.targetId === post.id);
+    expect(report).toBeDefined();
+
+    const resolveResponse = await apiRequest(
+      getServer().baseUrl,
+      `/api/reports/${report!.id}/resolve`,
+      { method: "POST" },
+      admin.jar,
+    );
+    expect(resolveResponse.status).toBe(200);
+
+    const listAfterResolve = await apiRequest(
+      getServer().baseUrl,
+      "/api/reports?status=pending",
+      {},
+      admin.jar,
+    );
+    const pendingAfter = (await listAfterResolve.json()) as { id: string }[];
+    expect(pendingAfter.find((item) => item.id === report!.id)).toBeUndefined();
+  });
+});

--- a/apps/api/tests/support/factories/admin.factory.ts
+++ b/apps/api/tests/support/factories/admin.factory.ts
@@ -1,0 +1,18 @@
+import { eq } from "drizzle-orm";
+import { db } from "../../../src/infrastructure/database/db";
+import { user } from "../../../src/infrastructure/database/auth.entity";
+import { profiles } from "../../../src/modules/users/users.entity";
+
+export const promoteToAdmin = async (username: string): Promise<void> => {
+  const [row] = await db
+    .select({ id: user.id })
+    .from(user)
+    .where(eq(user.username, username))
+    .limit(1);
+
+  if (!row) {
+    throw new Error(`Test user ${username} not found`);
+  }
+
+  await db.update(profiles).set({ isAdmin: true }).where(eq(profiles.userId, row.id));
+};

--- a/apps/web/src/components/layout/AppNavbar.tsx
+++ b/apps/web/src/components/layout/AppNavbar.tsx
@@ -4,6 +4,7 @@ import {
   MobileMenu,
   MobileMenuToggle,
   NavbarBrand,
+  NotificationsBell,
   PrimaryNavLinks,
   ProfileMenu,
 } from "@/components/layout/navbar/AppNavbarParts";
@@ -61,6 +62,8 @@ export const AppNavbar = () => {
                 LOADING
               </span>
             ) : null}
+
+            {user ? <NotificationsBell /> : null}
 
             {user ? (
               <ProfileMenu

--- a/apps/web/src/components/layout/navbar/AppNavbarParts.tsx
+++ b/apps/web/src/components/layout/navbar/AppNavbarParts.tsx
@@ -1,6 +1,7 @@
 export { NavbarBrand } from "@/components/layout/navbar/parts/NavbarBrand";
 export { PrimaryNavLinks } from "@/components/layout/navbar/parts/PrimaryNavLinks";
 export { DesktopSearchButton } from "@/components/layout/navbar/parts/DesktopSearchButton";
+export { NotificationsBell } from "@/components/layout/navbar/parts/NotificationsBell";
 export { ProfileMenu } from "@/components/layout/navbar/parts/ProfileMenu";
 export { DesktopGuestActions } from "@/components/layout/navbar/parts/DesktopGuestActions";
 export { MobileMenuToggle } from "@/components/layout/navbar/parts/MobileMenuToggle";

--- a/apps/web/src/components/layout/navbar/parts/NotificationsBell.tsx
+++ b/apps/web/src/components/layout/navbar/parts/NotificationsBell.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useRef, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { Bell } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
+import { useAuth } from "@/features/auth/hooks/useAuth";
+import { FeedActorAvatar } from "@/features/feed/components/FeedActorAvatar";
+import type { NotificationItem, NotificationType } from "@/features/notifications/api";
+import {
+  useMarkAllNotificationsRead,
+  useMarkNotificationRead,
+  useNotificationsList,
+  useUnreadNotificationCount,
+} from "@/features/notifications/hooks/useNotifications";
+import { formatRelativeTime } from "@/lib/time";
+
+const messageByType: Record<NotificationType, string> = {
+  follow: "started following you",
+  like_review: "liked your review",
+  like_post: "liked your post",
+  like_activity: "liked your activity",
+  comment_review: "commented on your review",
+  comment_post: "commented on your post",
+};
+
+type NotificationLink =
+  | { to: "/reviews/$username/$reviewId"; params: { username: string; reviewId: string } }
+  | { to: "/profile/$username"; params: { username: string } };
+
+const resolveNotificationLink = (
+  notification: NotificationItem,
+  ownUsername: string,
+): NotificationLink => {
+  if (notification.type === "like_review" || notification.type === "comment_review") {
+    return {
+      to: "/reviews/$username/$reviewId",
+      params: { username: ownUsername, reviewId: notification.entityId },
+    };
+  }
+
+  return {
+    to: "/profile/$username",
+    params: { username: notification.actorUsername },
+  };
+};
+
+export const NotificationsBell = () => {
+  const { user } = useAuth();
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  const unreadCountQuery = useUnreadNotificationCount(Boolean(user));
+  const listQuery = useNotificationsList(isOpen);
+  const markReadMutation = useMarkNotificationRead();
+  const markAllReadMutation = useMarkAllNotificationsRead();
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (
+        menuRef.current &&
+        event.target instanceof Node &&
+        !menuRef.current.contains(event.target)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener("mousedown", handleOutsideClick);
+    return () => window.removeEventListener("mousedown", handleOutsideClick);
+  }, [isOpen]);
+
+  if (!user) {
+    return null;
+  }
+
+  const unreadCount = unreadCountQuery.data ?? 0;
+  const notifications = listQuery.data?.items ?? [];
+
+  return (
+    <div ref={menuRef} className="relative self-stretch flex items-center">
+      <button
+        type="button"
+        onClick={() => setIsOpen((current) => !current)}
+        className="relative flex h-7 w-7 items-center justify-center border border-border/70 text-muted-foreground transition-colors hover:text-foreground"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-label="Open notifications"
+      >
+        <Bell className="h-3.5 w-3.5" aria-hidden="true" />
+        {unreadCount > 0 ? (
+          <span className="absolute -right-1 -top-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-0.5 font-mono text-[8px] font-bold text-primary-foreground">
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        ) : null}
+      </button>
+
+      {isOpen ? (
+        <div
+          className="absolute right-0 top-[calc(100%-1px)] z-50 w-72 border bg-popover/95 backdrop-blur-md animate-fade-up"
+          style={{ borderColor: "color-mix(in srgb, var(--primary) 30%, transparent)" }}
+          role="menu"
+          aria-label="Notifications"
+        >
+          <div className="flex items-center justify-between border-b border-border/70 px-3 py-2">
+            <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground">
+              Notifications
+            </p>
+            {unreadCount > 0 ? (
+              <button
+                type="button"
+                disabled={markAllReadMutation.isPending}
+                onClick={() => markAllReadMutation.mutate()}
+                className="font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+              >
+                Mark all read
+              </button>
+            ) : null}
+          </div>
+
+          <div className="max-h-96 overflow-y-auto">
+            {listQuery.isPending ? (
+              <div className="flex items-center justify-center py-8">
+                <Spinner />
+              </div>
+            ) : notifications.length === 0 ? (
+              <p className="py-8 text-center font-mono text-xs text-muted-foreground">
+                No notifications yet.
+              </p>
+            ) : (
+              <ul>
+                {notifications.map((notification) => {
+                  const avatarUrl =
+                    notification.actorAvatarUrl ?? notification.actorImage ?? null;
+                  const link = resolveNotificationLink(notification, user.username);
+
+                  return (
+                    <li key={notification.id}>
+                      <Link
+                        to={link.to}
+                        params={link.params}
+                        onClick={() => {
+                          setIsOpen(false);
+                          if (!notification.isRead) {
+                            markReadMutation.mutate(notification.id);
+                          }
+                        }}
+                        className={
+                          "flex items-start gap-2.5 border-b border-border/50 px-3 py-2.5 text-left transition-colors last:border-0 hover:bg-secondary/25 " +
+                          (notification.isRead ? "" : "bg-primary/5")
+                        }
+                      >
+                        <FeedActorAvatar
+                          avatarUrl={avatarUrl}
+                          username={notification.actorUsername}
+                          initial={notification.actorUsername.slice(0, 1).toUpperCase()}
+                          className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden border border-border/60"
+                        />
+                        <span className="min-w-0 flex-1">
+                          <span className="block font-mono text-[11px] text-foreground">
+                            <span className="font-semibold">
+                              {notification.actorDisplayUsername ?? notification.actorUsername}
+                            </span>{" "}
+                            {messageByType[notification.type]}
+                          </span>
+                          <span className="block font-mono text-[9px] text-muted-foreground">
+                            {formatRelativeTime(notification.createdAt.toISOString())}
+                          </span>
+                        </span>
+                        {!notification.isRead ? (
+                          <span
+                            className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
+                            aria-hidden="true"
+                          />
+                        ) : null}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/web/src/features/admin/api.ts
+++ b/apps/web/src/features/admin/api.ts
@@ -1,1 +1,65 @@
-export const adminFeaturePlaceholder = "Admin API will arrive in Phase 4.";
+import { z } from "zod";
+import { apiRequest } from "@/lib/api-client";
+
+export const reportStatusSchema = z.enum(["pending", "resolved", "dismissed"]);
+export type ReportStatus = z.infer<typeof reportStatusSchema>;
+
+const reportTargetTypeSchema = z.enum(["review", "post"]);
+const reportReasonSchema = z.enum(["spam", "harassment", "inappropriate", "other"]);
+
+const reportItemSchema = z.object({
+  id: z.string(),
+  reporterId: z.string(),
+  reporterUsername: z.string(),
+  targetType: reportTargetTypeSchema,
+  targetId: z.string(),
+  contentSnapshot: z.string(),
+  reason: reportReasonSchema,
+  details: z.string().nullable(),
+  status: reportStatusSchema,
+  createdAt: z.coerce.date(),
+  resolvedAt: z.coerce.date().nullable(),
+});
+export type ReportItem = z.infer<typeof reportItemSchema>;
+
+const adminUserSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  displayUsername: z.string().nullable(),
+  email: z.string(),
+  avatarUrl: z.string().nullable(),
+  isAdmin: z.boolean(),
+  createdAt: z.coerce.date(),
+});
+export type AdminUser = z.infer<typeof adminUserSchema>;
+
+const actionResponseSchema = z.object({ success: z.boolean() });
+
+export const listReports = async (status?: ReportStatus): Promise<ReportItem[]> => {
+  const query = status ? `?status=${status}` : "";
+  const response = await apiRequest<unknown>(`/api/reports${query}`, { method: "GET" });
+  return z.array(reportItemSchema).parse(response);
+};
+
+export const resolveReport = async (id: string): Promise<void> => {
+  const response = await apiRequest<unknown>(`/api/reports/${id}/resolve`, { method: "POST" });
+  actionResponseSchema.parse(response);
+};
+
+export const dismissReport = async (id: string): Promise<void> => {
+  const response = await apiRequest<unknown>(`/api/reports/${id}/dismiss`, { method: "POST" });
+  actionResponseSchema.parse(response);
+};
+
+export const removeReportedContent = async (id: string): Promise<void> => {
+  const response = await apiRequest<unknown>(`/api/reports/${id}/remove-content`, {
+    method: "POST",
+  });
+  actionResponseSchema.parse(response);
+};
+
+export const listAdminUsers = async (query?: string): Promise<AdminUser[]> => {
+  const params = query ? `?query=${encodeURIComponent(query)}` : "";
+  const response = await apiRequest<unknown>(`/api/admin/users${params}`, { method: "GET" });
+  return z.array(adminUserSchema).parse(response);
+};

--- a/apps/web/src/features/admin/components/AdminDashboardPage.tsx
+++ b/apps/web/src/features/admin/components/AdminDashboardPage.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { AdminReportsPanel } from "@/features/admin/components/AdminReportsPanel";
+import { AdminUsersPanel } from "@/features/admin/components/AdminUsersPanel";
+
+const TABS = [
+  { value: "reports", label: "Reports" },
+  { value: "users", label: "Users" },
+] as const;
+
+type AdminTab = (typeof TABS)[number]["value"];
+
+export const AdminDashboardPage = () => {
+  const [tab, setTab] = useState<AdminTab>("reports");
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center gap-2 border-b border-border/60 pb-3">
+        {TABS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => setTab(option.value)}
+            className={
+              "border px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] transition-colors " +
+              (tab === option.value
+                ? "border-primary/45 bg-primary/10 text-primary"
+                : "border-border/70 text-muted-foreground hover:text-foreground")
+            }
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "reports" ? <AdminReportsPanel /> : <AdminUsersPanel />}
+    </div>
+  );
+};

--- a/apps/web/src/features/admin/components/AdminPlaceholder.tsx
+++ b/apps/web/src/features/admin/components/AdminPlaceholder.tsx
@@ -1,9 +1,0 @@
-import { Card, CardContent } from "@/components/ui/card";
-
-export const AdminPlaceholder = () => (
-  <Card>
-    <CardContent className="p-4 text-sm text-muted-foreground">
-      Admin panel is scheduled for Phase 4.
-    </CardContent>
-  </Card>
-);

--- a/apps/web/src/features/admin/components/AdminReportsPanel.tsx
+++ b/apps/web/src/features/admin/components/AdminReportsPanel.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import type { ReportItem, ReportStatus } from "@/features/admin/api";
+import {
+  useAdminReports,
+  useDismissReport,
+  useRemoveReportedContent,
+  useResolveReport,
+} from "@/features/admin/hooks/useAdmin";
+import { formatRelativeTime } from "@/lib/time";
+
+const STATUS_TABS: { value: ReportStatus; label: string }[] = [
+  { value: "pending", label: "Pending" },
+  { value: "resolved", label: "Resolved" },
+  { value: "dismissed", label: "Dismissed" },
+];
+
+const ReportRow = ({ report }: { report: ReportItem }) => {
+  const resolveMutation = useResolveReport();
+  const dismissMutation = useDismissReport();
+  const removeMutation = useRemoveReportedContent();
+  const isPending = resolveMutation.isPending || dismissMutation.isPending || removeMutation.isPending;
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Badge variant="muted">{report.targetType}</Badge>
+            <Badge variant="muted">{report.reason}</Badge>
+            <span className="text-xs text-muted-foreground">
+              reported by @{report.reporterUsername} · {formatRelativeTime(report.createdAt.toISOString())}
+            </span>
+          </div>
+          <Badge>{report.status}</Badge>
+        </div>
+
+        <p className="line-clamp-3 whitespace-pre-wrap text-sm text-foreground/90">
+          {report.contentSnapshot}
+        </p>
+
+        {report.details ? (
+          <p className="text-xs text-muted-foreground">Reporter note: {report.details}</p>
+        ) : null}
+
+        {report.status === "pending" ? (
+          <div className="flex items-center gap-2 pt-1">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={isPending}
+              onClick={() => dismissMutation.mutate(report.id)}
+            >
+              Dismiss
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={isPending}
+              onClick={() => resolveMutation.mutate(report.id)}
+            >
+              Mark resolved
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="danger"
+              disabled={isPending}
+              onClick={() => {
+                if (window.confirm("Remove this content? This cannot be undone.")) {
+                  removeMutation.mutate(report.id);
+                }
+              }}
+            >
+              Remove content
+            </Button>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+};
+
+export const AdminReportsPanel = () => {
+  const [status, setStatus] = useState<ReportStatus>("pending");
+  const reportsQuery = useAdminReports(status);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        {STATUS_TABS.map((tab) => (
+          <button
+            key={tab.value}
+            type="button"
+            onClick={() => setStatus(tab.value)}
+            className={
+              "border px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em] transition-colors " +
+              (status === tab.value
+                ? "border-primary/45 bg-primary/10 text-primary"
+                : "border-border/70 text-muted-foreground hover:text-foreground")
+            }
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {reportsQuery.isPending ? (
+        <div className="flex items-center justify-center py-10">
+          <Spinner />
+        </div>
+      ) : reportsQuery.isError ? (
+        <p className="text-sm text-muted-foreground">Could not load reports.</p>
+      ) : reportsQuery.data.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No {status} reports.</p>
+      ) : (
+        <div className="space-y-3">
+          {reportsQuery.data.map((report) => (
+            <ReportRow key={report.id} report={report} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/features/admin/components/AdminUsersPanel.tsx
+++ b/apps/web/src/features/admin/components/AdminUsersPanel.tsx
@@ -1,0 +1,74 @@
+import { useDeferredValue, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { useAdminUsers } from "@/features/admin/hooks/useAdmin";
+import { formatRelativeTime } from "@/lib/time";
+
+export const AdminUsersPanel = () => {
+  const [queryInput, setQueryInput] = useState("");
+  const deferredQuery = useDeferredValue(queryInput.trim());
+  const usersQuery = useAdminUsers(deferredQuery.length > 0 ? deferredQuery : undefined);
+
+  return (
+    <div className="space-y-4">
+      <Input
+        value={queryInput}
+        onChange={(event) => setQueryInput(event.target.value)}
+        placeholder="Search by username..."
+        className="max-w-sm"
+      />
+
+      {usersQuery.isPending ? (
+        <div className="flex items-center justify-center py-10">
+          <Spinner />
+        </div>
+      ) : usersQuery.isError ? (
+        <p className="text-sm text-muted-foreground">Could not load users.</p>
+      ) : usersQuery.data.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No users found.</p>
+      ) : (
+        <div className="border border-border/60">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border/60 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="px-3 py-2">User</th>
+                <th className="px-3 py-2">Email</th>
+                <th className="px-3 py-2">Joined</th>
+                <th className="px-3 py-2">Role</th>
+              </tr>
+            </thead>
+            <tbody>
+              {usersQuery.data.map((adminUser) => (
+                <tr key={adminUser.id} className="border-b border-border/40 last:border-0">
+                  <td className="px-3 py-2">
+                    <Link
+                      to="/profile/$username"
+                      params={{ username: adminUser.username }}
+                      className="text-primary hover:underline"
+                    >
+                      @{adminUser.username}
+                    </Link>
+                    {adminUser.displayUsername ? (
+                      <span className="ml-1 text-xs text-muted-foreground">
+                        ({adminUser.displayUsername})
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">{adminUser.email}</td>
+                  <td className="px-3 py-2 text-muted-foreground">
+                    {formatRelativeTime(adminUser.createdAt.toISOString())}
+                  </td>
+                  <td className="px-3 py-2">
+                    {adminUser.isAdmin ? <Badge>Admin</Badge> : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/features/admin/hooks/useAdmin.ts
+++ b/apps/web/src/features/admin/hooks/useAdmin.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  dismissReport,
+  listAdminUsers,
+  listReports,
+  removeReportedContent,
+  resolveReport,
+  type ReportStatus,
+} from "@/features/admin/api";
+
+export const adminKeys = {
+  reports: (status?: ReportStatus) => ["admin", "reports", status ?? "all"] as const,
+  users: (query?: string) => ["admin", "users", query ?? ""] as const,
+};
+
+export const useAdminReports = (status?: ReportStatus) =>
+  useQuery({
+    queryKey: adminKeys.reports(status),
+    queryFn: () => listReports(status),
+  });
+
+export const useAdminUsers = (query?: string) =>
+  useQuery({
+    queryKey: adminKeys.users(query),
+    queryFn: () => listAdminUsers(query),
+  });
+
+const useReportAction = (mutationFn: (id: string) => Promise<void>) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["admin", "reports"] });
+    },
+  });
+};
+
+export const useResolveReport = () => useReportAction(resolveReport);
+export const useDismissReport = () => useReportAction(dismissReport);
+export const useRemoveReportedContent = () => useReportAction(removeReportedContent);

--- a/apps/web/src/features/feed/components/PostActivityCard.tsx
+++ b/apps/web/src/features/feed/components/PostActivityCard.tsx
@@ -1,6 +1,6 @@
 import { memo, useMemo, useState, type CSSProperties, type MouseEvent } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { CornerDownRight, Heart, Loader2, MessageSquare, PenSquare } from "lucide-react";
+import { CornerDownRight, Flag, Heart, Loader2, MessageSquare, PenSquare } from "lucide-react";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { FeedActorAvatar } from "@/features/feed/components/FeedActorAvatar";
 import { PostActivityDialog } from "@/features/feed/components/PostActivityDialog";
@@ -11,6 +11,7 @@ import {
 } from "@/features/feed/components/feed-row.utils";
 import type { FeedItem } from "@/features/feed/types";
 import { useLikePost, useUnlikePost } from "@/features/posts/hooks/usePosts";
+import { ReportContentDialog } from "@/features/reports/components/ReportContentDialog";
 import { cn } from "@/lib/utils";
 
 type PostActivityCardProps = {
@@ -50,6 +51,7 @@ export const PostActivityCard = memo(function PostActivityCard({ item }: PostAct
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [dialogMode, setDialogMode] = useState<"view" | "edit">("view");
+  const [isReportDialogOpen, setIsReportDialogOpen] = useState(false);
 
   const channelVisual = useMemo(() => {
     if (channel) {
@@ -108,6 +110,16 @@ export const PostActivityCard = memo(function PostActivityCard({ item }: PostAct
     }
 
     openDialog("view");
+  };
+
+  const handleReport = async () => {
+    if (!user) {
+      const redirectPath = `${window.location.pathname}${window.location.search}`;
+      await navigate({ to: "/login", search: { redirect: redirectPath } });
+      return;
+    }
+
+    setIsReportDialogOpen(true);
   };
 
   return (
@@ -213,6 +225,19 @@ export const PostActivityCard = memo(function PostActivityCard({ item }: PostAct
               EDIT
             </button>
           ) : null}
+
+          {!isOwnPost && postId ? (
+            <button
+              type="button"
+              onClick={() => {
+                void handleReport();
+              }}
+              className="ml-auto inline-flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground transition-colors hover:text-destructive"
+            >
+              <Flag className="h-3.5 w-3.5" />
+              REPORT
+            </button>
+          ) : null}
         </div>
       </article>
 
@@ -225,6 +250,15 @@ export const PostActivityCard = memo(function PostActivityCard({ item }: PostAct
             setIsDialogOpen(false);
             setDialogMode("view");
           }}
+        />
+      ) : null}
+
+      {postId ? (
+        <ReportContentDialog
+          isOpen={isReportDialogOpen}
+          onClose={() => setIsReportDialogOpen(false)}
+          targetType="post"
+          targetId={postId}
         />
       ) : null}
     </>

--- a/apps/web/src/features/moderation/api.ts
+++ b/apps/web/src/features/moderation/api.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import { apiRequest } from "@/lib/api-client";
+
+const relationshipStateSchema = z.object({
+  isBlocked: z.boolean(),
+  isMuted: z.boolean(),
+});
+
+const moderationActionResponseSchema = z.object({
+  success: z.boolean(),
+});
+
+const moderatedUserSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  displayUsername: z.string().nullish(),
+  image: z.string().nullish(),
+  avatarUrl: z.string().nullish(),
+  createdAt: z.coerce.date(),
+});
+
+export type RelationshipState = z.infer<typeof relationshipStateSchema>;
+export type ModerationActionResponse = z.infer<typeof moderationActionResponseSchema>;
+export type ModeratedUser = z.infer<typeof moderatedUserSchema>;
+
+export const getRelationshipState = async (username: string): Promise<RelationshipState> => {
+  const response = await apiRequest<unknown>(
+    `/api/moderation/state/${encodeURIComponent(username)}`,
+    { method: "GET" },
+  );
+  return relationshipStateSchema.parse(response);
+};
+
+export const blockUser = async (username: string): Promise<ModerationActionResponse> => {
+  const response = await apiRequest<unknown>(
+    `/api/moderation/block/${encodeURIComponent(username)}`,
+    { method: "POST" },
+  );
+  return moderationActionResponseSchema.parse(response);
+};
+
+export const unblockUser = async (username: string): Promise<ModerationActionResponse> => {
+  const response = await apiRequest<unknown>(
+    `/api/moderation/block/${encodeURIComponent(username)}`,
+    { method: "DELETE" },
+  );
+  return moderationActionResponseSchema.parse(response);
+};
+
+export const muteUser = async (username: string): Promise<ModerationActionResponse> => {
+  const response = await apiRequest<unknown>(
+    `/api/moderation/mute/${encodeURIComponent(username)}`,
+    { method: "POST" },
+  );
+  return moderationActionResponseSchema.parse(response);
+};
+
+export const unmuteUser = async (username: string): Promise<ModerationActionResponse> => {
+  const response = await apiRequest<unknown>(
+    `/api/moderation/mute/${encodeURIComponent(username)}`,
+    { method: "DELETE" },
+  );
+  return moderationActionResponseSchema.parse(response);
+};
+
+export const getBlockedUsers = async (): Promise<ModeratedUser[]> => {
+  const response = await apiRequest<unknown>("/api/moderation/blocked", { method: "GET" });
+  return z.array(moderatedUserSchema).parse(response);
+};
+
+export const getMutedUsers = async (): Promise<ModeratedUser[]> => {
+  const response = await apiRequest<unknown>("/api/moderation/muted", { method: "GET" });
+  return z.array(moderatedUserSchema).parse(response);
+};

--- a/apps/web/src/features/moderation/hooks/useModeration.ts
+++ b/apps/web/src/features/moderation/hooks/useModeration.ts
@@ -1,0 +1,134 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { feedKeys } from "@/features/feed/hooks/useFeed";
+import {
+  blockUser,
+  getBlockedUsers,
+  getMutedUsers,
+  getRelationshipState,
+  muteUser,
+  unblockUser,
+  unmuteUser,
+  type RelationshipState,
+} from "@/features/moderation/api";
+import { socialKeys } from "@/features/social/hooks/useSocial";
+
+export const moderationKeys = {
+  relationshipState: (username: string) =>
+    ["moderation", "state", username] as const,
+  blocked: ["moderation", "blocked"] as const,
+  muted: ["moderation", "muted"] as const,
+};
+
+export const useRelationshipState = (username: string, enabled = true) =>
+  useQuery({
+    queryKey: moderationKeys.relationshipState(username),
+    queryFn: () => getRelationshipState(username),
+    enabled: enabled && username.trim().length > 0,
+  });
+
+export const useBlockedUsers = (enabled = true) =>
+  useQuery({
+    queryKey: moderationKeys.blocked,
+    queryFn: getBlockedUsers,
+    enabled,
+  });
+
+export const useMutedUsers = (enabled = true) =>
+  useQuery({
+    queryKey: moderationKeys.muted,
+    queryFn: getMutedUsers,
+    enabled,
+  });
+
+export const useBlockUser = (username: string) => {
+  const queryClient = useQueryClient();
+  const stateKey = moderationKeys.relationshipState(username);
+
+  return useMutation({
+    mutationFn: () => blockUser(username),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: stateKey });
+      const previous = queryClient.getQueryData<RelationshipState>(stateKey);
+      queryClient.setQueryData<RelationshipState>(stateKey, {
+        isBlocked: true,
+        isMuted: false,
+      });
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(stateKey, context.previous);
+      }
+    },
+    onSettled: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: stateKey }),
+        queryClient.invalidateQueries({ queryKey: socialKeys.followState(username) }),
+        queryClient.invalidateQueries({ queryKey: moderationKeys.blocked }),
+        queryClient.invalidateQueries({ queryKey: feedKeys.following }),
+      ]);
+    },
+  });
+};
+
+export const useUnblockUser = (username: string) => {
+  const queryClient = useQueryClient();
+  const stateKey = moderationKeys.relationshipState(username);
+
+  return useMutation({
+    mutationFn: () => unblockUser(username),
+    onSettled: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: stateKey }),
+        queryClient.invalidateQueries({ queryKey: moderationKeys.blocked }),
+        queryClient.invalidateQueries({ queryKey: feedKeys.following }),
+      ]);
+    },
+  });
+};
+
+export const useMuteUser = (username: string) => {
+  const queryClient = useQueryClient();
+  const stateKey = moderationKeys.relationshipState(username);
+
+  return useMutation({
+    mutationFn: () => muteUser(username),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: stateKey });
+      const previous = queryClient.getQueryData<RelationshipState>(stateKey);
+      queryClient.setQueryData<RelationshipState>(stateKey, (old) => ({
+        isBlocked: old?.isBlocked ?? false,
+        isMuted: true,
+      }));
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(stateKey, context.previous);
+      }
+    },
+    onSettled: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: stateKey }),
+        queryClient.invalidateQueries({ queryKey: moderationKeys.muted }),
+        queryClient.invalidateQueries({ queryKey: feedKeys.following }),
+      ]);
+    },
+  });
+};
+
+export const useUnmuteUser = (username: string) => {
+  const queryClient = useQueryClient();
+  const stateKey = moderationKeys.relationshipState(username);
+
+  return useMutation({
+    mutationFn: () => unmuteUser(username),
+    onSettled: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: stateKey }),
+        queryClient.invalidateQueries({ queryKey: moderationKeys.muted }),
+        queryClient.invalidateQueries({ queryKey: feedKeys.following }),
+      ]);
+    },
+  });
+};

--- a/apps/web/src/features/notifications/api.ts
+++ b/apps/web/src/features/notifications/api.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { apiRequest } from "@/lib/api-client";
+
+export const notificationTypeSchema = z.enum([
+  "follow",
+  "like_review",
+  "like_post",
+  "like_activity",
+  "comment_review",
+  "comment_post",
+]);
+
+const notificationItemSchema = z.object({
+  id: z.string(),
+  actorId: z.string(),
+  actorUsername: z.string(),
+  actorDisplayUsername: z.string().nullish(),
+  actorImage: z.string().nullish(),
+  actorAvatarUrl: z.string().nullish(),
+  type: notificationTypeSchema,
+  entityId: z.string(),
+  metadata: z.string().nullable(),
+  isRead: z.boolean(),
+  createdAt: z.coerce.date(),
+});
+
+const notificationPageSchema = z.object({
+  items: z.array(notificationItemSchema),
+  nextCursor: z.string().nullable(),
+});
+
+const unreadCountSchema = z.object({ count: z.number() });
+
+export type NotificationType = z.infer<typeof notificationTypeSchema>;
+export type NotificationItem = z.infer<typeof notificationItemSchema>;
+export type NotificationPage = z.infer<typeof notificationPageSchema>;
+
+export const getNotifications = async (
+  limit?: number,
+  cursor?: string,
+): Promise<NotificationPage> => {
+  const params = new URLSearchParams();
+  if (limit) params.set("limit", String(limit));
+  if (cursor) params.set("cursor", cursor);
+  const query = params.toString();
+
+  const response = await apiRequest<unknown>(
+    `/api/notifications${query ? `?${query}` : ""}`,
+    { method: "GET" },
+  );
+  return notificationPageSchema.parse(response);
+};
+
+export const getUnreadNotificationCount = async (): Promise<number> => {
+  const response = await apiRequest<unknown>("/api/notifications/unread-count", {
+    method: "GET",
+  });
+  return unreadCountSchema.parse(response).count;
+};
+
+export const markNotificationRead = async (id: string): Promise<void> => {
+  await apiRequest(`/api/notifications/${id}/read`, { method: "POST" });
+};
+
+export const markAllNotificationsRead = async (): Promise<void> => {
+  await apiRequest("/api/notifications/read-all", { method: "POST" });
+};

--- a/apps/web/src/features/notifications/hooks/useNotifications.ts
+++ b/apps/web/src/features/notifications/hooks/useNotifications.ts
@@ -1,0 +1,57 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getNotifications,
+  getUnreadNotificationCount,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from "@/features/notifications/api";
+
+const UNREAD_COUNT_POLL_INTERVAL_MS = 30_000;
+
+export const notificationKeys = {
+  list: ["notifications", "list"] as const,
+  unreadCount: ["notifications", "unread-count"] as const,
+};
+
+export const useNotificationsList = (enabled: boolean) =>
+  useQuery({
+    queryKey: notificationKeys.list,
+    queryFn: () => getNotifications(20),
+    enabled,
+  });
+
+export const useUnreadNotificationCount = (enabled = true) =>
+  useQuery({
+    queryKey: notificationKeys.unreadCount,
+    queryFn: getUnreadNotificationCount,
+    enabled,
+    refetchInterval: enabled ? UNREAD_COUNT_POLL_INTERVAL_MS : false,
+  });
+
+export const useMarkNotificationRead = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => markNotificationRead(id),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: notificationKeys.list }),
+        queryClient.invalidateQueries({ queryKey: notificationKeys.unreadCount }),
+      ]);
+    },
+  });
+};
+
+export const useMarkAllNotificationsRead = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: markAllNotificationsRead,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: notificationKeys.list }),
+        queryClient.invalidateQueries({ queryKey: notificationKeys.unreadCount }),
+      ]);
+    },
+  });
+};

--- a/apps/web/src/features/profile/layout/ProfileLayout.tsx
+++ b/apps/web/src/features/profile/layout/ProfileLayout.tsx
@@ -15,6 +15,13 @@ import {
   useFollowUser,
   useUnfollowUser,
 } from "@/features/social/hooks/useSocial";
+import {
+  useBlockUser,
+  useMuteUser,
+  useRelationshipState,
+  useUnblockUser,
+  useUnmuteUser,
+} from "@/features/moderation/hooks/useModeration";
 import { isApiError } from "@/lib/api-client";
 import type { PublicProfile } from "@/types/api";
 
@@ -49,6 +56,15 @@ export const ProfileLayout = ({
   );
   const followMutation = useFollowUser(username);
   const unfollowMutation = useUnfollowUser(username);
+
+  const relationshipStateQuery = useRelationshipState(
+    username,
+    isViewerLoggedIn && !isOwnProfileByRoute,
+  );
+  const blockMutation = useBlockUser(username);
+  const unblockMutation = useUnblockUser(username);
+  const muteMutation = useMuteUser(username);
+  const unmuteMutation = useUnmuteUser(username);
 
   if (profileQuery.isPending) {
     return (
@@ -99,6 +115,27 @@ export const ProfileLayout = ({
     }
   };
 
+  const isBlocked = relationshipStateQuery.data?.isBlocked ?? false;
+  const isMuted = relationshipStateQuery.data?.isMuted ?? false;
+  const isBlockActionPending = blockMutation.isPending || unblockMutation.isPending;
+  const isMuteActionPending = muteMutation.isPending || unmuteMutation.isPending;
+
+  const handleToggleBlock = () => {
+    if (isBlocked) {
+      unblockMutation.mutate();
+      return;
+    }
+    blockMutation.mutate();
+  };
+
+  const handleToggleMute = () => {
+    if (isMuted) {
+      unmuteMutation.mutate();
+      return;
+    }
+    muteMutation.mutate();
+  };
+
   const actionClassName =
     "flex items-center gap-1.5 border px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] transition-colors profile-shell-border profile-shell-muted hover:text-foreground";
 
@@ -111,23 +148,43 @@ export const ProfileLayout = ({
       <Settings className="h-3 w-3" aria-hidden="true" />
     </Link>
   ) : isViewerLoggedIn ? (
-    <button
-      type="button"
-      className={actionClassName}
-      disabled={followStateQuery.isPending || isFollowActionPending}
-      onClick={() => {
-        void handleToggleFollow();
-      }}
-      aria-label="Follow user"
-    >
-      {followStateQuery.isPending
-        ? "Loading"
-        : isFollowActionPending
-          ? "Saving"
-          : isFollowing
-            ? "Following"
-            : "Follow"}
-    </button>
+    <div className="flex items-center gap-1.5">
+      <button
+        type="button"
+        className={actionClassName}
+        disabled={followStateQuery.isPending || isFollowActionPending || isBlocked}
+        onClick={() => {
+          void handleToggleFollow();
+        }}
+        aria-label="Follow user"
+      >
+        {followStateQuery.isPending
+          ? "Loading"
+          : isFollowActionPending
+            ? "Saving"
+            : isFollowing
+              ? "Following"
+              : "Follow"}
+      </button>
+      <button
+        type="button"
+        className={actionClassName}
+        disabled={relationshipStateQuery.isPending || isMuteActionPending}
+        onClick={handleToggleMute}
+        aria-label={isMuted ? "Unmute user" : "Mute user"}
+      >
+        {isMuteActionPending ? "Saving" : isMuted ? "Muted" : "Mute"}
+      </button>
+      <button
+        type="button"
+        className={actionClassName}
+        disabled={relationshipStateQuery.isPending || isBlockActionPending}
+        onClick={handleToggleBlock}
+        aria-label={isBlocked ? "Unblock user" : "Block user"}
+      >
+        {isBlockActionPending ? "Saving" : isBlocked ? "Blocked" : "Block"}
+      </button>
+    </div>
   ) : (
     <Link
       to="/login"

--- a/apps/web/src/features/reports/api.ts
+++ b/apps/web/src/features/reports/api.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { apiRequest } from "@/lib/api-client";
+
+export const reportReasonSchema = z.enum(["spam", "harassment", "inappropriate", "other"]);
+export type ReportReason = z.infer<typeof reportReasonSchema>;
+
+export const reportTargetTypeSchema = z.enum(["review", "post"]);
+export type ReportTargetType = z.infer<typeof reportTargetTypeSchema>;
+
+const reportActionResponseSchema = z.object({ success: z.boolean() });
+
+export type SubmitReportInput = {
+  targetType: ReportTargetType;
+  targetId: string;
+  reason: ReportReason;
+  details?: string;
+};
+
+export const submitReport = async (input: SubmitReportInput): Promise<void> => {
+  const response = await apiRequest<unknown, SubmitReportInput>("/api/reports", {
+    method: "POST",
+    body: input,
+  });
+  reportActionResponseSchema.parse(response);
+};

--- a/apps/web/src/features/reports/components/ReportContentDialog.tsx
+++ b/apps/web/src/features/reports/components/ReportContentDialog.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { Loader2, X } from "lucide-react";
+import { Textarea } from "@/components/ui/textarea";
+import { useSubmitReport } from "@/features/reports/hooks/useReports";
+import type { ReportReason, ReportTargetType } from "@/features/reports/api";
+import { isApiError } from "@/lib/api-client";
+import { cn } from "@/lib/utils";
+
+type ReportContentDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  targetType: ReportTargetType;
+  targetId: string;
+};
+
+const REASON_OPTIONS: { value: ReportReason; label: string }[] = [
+  { value: "spam", label: "Spam" },
+  { value: "harassment", label: "Harassment" },
+  { value: "inappropriate", label: "Inappropriate content" },
+  { value: "other", label: "Other" },
+];
+
+export const ReportContentDialog = ({ isOpen, ...rest }: ReportContentDialogProps) => {
+  return isOpen ? (
+    <ReportContentDialogContent key={`${rest.targetType}-${rest.targetId}`} {...rest} />
+  ) : null;
+};
+
+type ReportContentDialogContentProps = Omit<ReportContentDialogProps, "isOpen">;
+
+const ReportContentDialogContent = ({
+  onClose,
+  targetType,
+  targetId,
+}: ReportContentDialogContentProps) => {
+  const [reason, setReason] = useState<ReportReason>("spam");
+  const [details, setDetails] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const submitReportMutation = useSubmitReport();
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onClose]);
+
+  const handleSubmit = async () => {
+    if (submitReportMutation.isPending) {
+      return;
+    }
+
+    await submitReportMutation.mutateAsync({
+      targetType,
+      targetId,
+      reason,
+      details: details.trim().length > 0 ? details.trim() : undefined,
+    });
+    setSubmitted(true);
+  };
+
+  return createPortal(
+    <div className="theme-modal-overlay fixed inset-0 z-140 bg-background/70 backdrop-blur-sm">
+      <button
+        type="button"
+        aria-label="Close report dialog"
+        className="absolute inset-0"
+        onClick={onClose}
+      />
+
+      <div className="relative mx-auto flex h-full w-full max-w-md items-center justify-center p-4">
+        <section className="theme-modal-panel relative w-full overflow-hidden border border-border/80 bg-card/95 p-0 animate-fade-up">
+          <div className="flex items-start justify-between border-b border-border/70 px-4 py-3">
+            <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+              Report {targetType}
+            </p>
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex h-7 w-7 items-center justify-center border border-border/70 text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          {submitted ? (
+            <div className="space-y-4 px-4 py-6 text-center">
+              <p className="font-mono text-sm text-foreground">
+                Thanks — this has been reported for review.
+              </p>
+              <button
+                type="button"
+                onClick={onClose}
+                className="border border-border/70 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
+              >
+                Close
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-3 px-4 py-4">
+              <div className="space-y-1.5">
+                {REASON_OPTIONS.map((option) => (
+                  <label
+                    key={option.value}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-2 border px-3 py-1.5 font-mono text-xs transition-colors",
+                      reason === option.value
+                        ? "border-primary/45 bg-primary/10 text-primary"
+                        : "border-border/70 text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    <input
+                      type="radio"
+                      name="report-reason"
+                      value={option.value}
+                      checked={reason === option.value}
+                      onChange={() => setReason(option.value)}
+                      className="sr-only"
+                    />
+                    {option.label}
+                  </label>
+                ))}
+              </div>
+
+              <Textarea
+                value={details}
+                onChange={(event) => {
+                  if (event.target.value.length <= 1000) {
+                    setDetails(event.target.value);
+                  }
+                }}
+                placeholder="Additional details (optional)"
+                className="min-h-20 border-border/75 bg-background/45 font-mono text-sm"
+              />
+
+              <div className="flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="border border-border/70 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground"
+                >
+                  cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    void handleSubmit();
+                  }}
+                  disabled={submitReportMutation.isPending}
+                  className="border border-primary/45 bg-primary/10 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-primary disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {submitReportMutation.isPending ? (
+                    <span className="inline-flex items-center gap-1">
+                      <Loader2 className="h-3 w-3 animate-spin" /> submitting
+                    </span>
+                  ) : (
+                    "submit report"
+                  )}
+                </button>
+              </div>
+
+              {submitReportMutation.isError ? (
+                <p className="font-mono text-[11px] text-destructive">
+                  {isApiError(submitReportMutation.error)
+                    ? submitReportMutation.error.message
+                    : "Could not submit report."}
+                </p>
+              ) : null}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/apps/web/src/features/reports/hooks/useReports.ts
+++ b/apps/web/src/features/reports/hooks/useReports.ts
@@ -1,0 +1,7 @@
+import { useMutation } from "@tanstack/react-query";
+import { submitReport, type SubmitReportInput } from "@/features/reports/api";
+
+export const useSubmitReport = () =>
+  useMutation({
+    mutationFn: (input: SubmitReportInput) => submitReport(input),
+  });

--- a/apps/web/src/features/reviews/components/ProfileReviewDetailPage.tsx
+++ b/apps/web/src/features/reviews/components/ProfileReviewDetailPage.tsx
@@ -17,6 +17,7 @@ import {
   useReviewDetail,
   useUnlikeReview,
 } from "@/features/reviews/hooks/useReviews";
+import { ReportContentDialog } from "@/features/reports/components/ReportContentDialog";
 
 type ProfileReviewDetailPageProps = {
   username: string;
@@ -32,6 +33,7 @@ export function ProfileReviewDetailPage({
 
   const [commentDraft, setCommentDraft] = useState("");
   const [isSpoilerRevealed, setIsSpoilerRevealed] = useState(false);
+  const [isReportDialogOpen, setIsReportDialogOpen] = useState(false);
 
   const detailQuery = useReviewDetail(
     username,
@@ -62,6 +64,9 @@ export function ProfileReviewDetailPage({
   const displayAuthorName =
     detail.author.displayUsername ?? detail.author.username;
   const authorAvatar = detail.author.avatarUrl ?? detail.author.image;
+  const isOwnReview =
+    user !== null &&
+    user.username.toLowerCase() === detail.author.username.toLowerCase();
   const likeBusy =
     likeReviewMutation.isPending || unlikeReviewMutation.isPending;
   const comments = commentsQuery.data ?? [];
@@ -113,8 +118,24 @@ export function ProfileReviewDetailPage({
     setCommentDraft("");
   };
 
+  const handleReport = async () => {
+    if (!user) {
+      await goToLogin();
+      return;
+    }
+
+    setIsReportDialogOpen(true);
+  };
+
   return (
     <div className="min-h-screen">
+      <ReportContentDialog
+        isOpen={isReportDialogOpen}
+        onClose={() => setIsReportDialogOpen(false)}
+        targetType="review"
+        targetId={reviewId}
+      />
+
       <ProfileReviewDetailHero
         username={username}
         detail={detail}
@@ -132,6 +153,10 @@ export function ProfileReviewDetailPage({
             onRevealSpoiler={() => setIsSpoilerRevealed(true)}
             likeBusy={likeBusy}
             onToggleLike={toggleLike}
+            showReportAction={!isOwnReview}
+            onReport={() => {
+              void handleReport();
+            }}
           />
 
           <ProfileReviewCommentsSection

--- a/apps/web/src/features/reviews/components/profile-review-detail/ProfileReviewSection.tsx
+++ b/apps/web/src/features/reviews/components/profile-review-detail/ProfileReviewSection.tsx
@@ -1,4 +1,4 @@
-import { Heart, Loader2, MessageSquare, TriangleAlert } from "lucide-react";
+import { Flag, Heart, Loader2, MessageSquare, TriangleAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { ReviewDetail } from "@/features/reviews/api";
 import { cn } from "@/lib/utils";
@@ -9,6 +9,8 @@ type ProfileReviewSectionProps = {
   onRevealSpoiler: () => void;
   likeBusy: boolean;
   onToggleLike: () => void;
+  showReportAction: boolean;
+  onReport: () => void;
 };
 
 export const ProfileReviewSection = ({
@@ -17,6 +19,8 @@ export const ProfileReviewSection = ({
   onRevealSpoiler,
   likeBusy,
   onToggleLike,
+  showReportAction,
+  onReport,
 }: ProfileReviewSectionProps) => {
   return (
     <section className="border border-border/60 bg-card/35 p-5 sm:p-6">
@@ -72,6 +76,19 @@ export const ProfileReviewSection = ({
           <MessageSquare className="h-3.5 w-3.5" />
           {detail.engagement.commentCount}
         </span>
+
+        {showReportAction ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="ml-auto text-muted-foreground hover:text-destructive"
+            onClick={onReport}
+          >
+            <Flag className="h-3.5 w-3.5" />
+            Report
+          </Button>
+        ) : null}
       </div>
     </section>
   );

--- a/apps/web/src/features/search/api.ts
+++ b/apps/web/src/features/search/api.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import { apiRequest } from "@/lib/api-client";
+import type { QueryRequestOptions } from "@/features/films/api";
+
+export const unifiedSearchResultSchema = z.object({
+  mediaType: z.enum(["movie", "tv"]),
+  tmdbId: z.number(),
+  title: z.string(),
+  posterPath: z.string().nullable(),
+  releaseDate: z.string().nullable(),
+  popularity: z.number(),
+});
+
+export type UnifiedSearchResult = z.infer<typeof unifiedSearchResultSchema>;
+
+const unifiedSearchResponseSchema = z.array(unifiedSearchResultSchema);
+
+export const searchTitles = async (
+  query: string,
+  options: QueryRequestOptions = {},
+): Promise<UnifiedSearchResult[]> => {
+  const normalizedQuery = query.trim();
+  if (normalizedQuery.length === 0) {
+    return [];
+  }
+
+  const response = await apiRequest<unknown>(
+    `/api/search?query=${encodeURIComponent(normalizedQuery)}`,
+    { method: "GET", signal: options.signal },
+  );
+
+  return unifiedSearchResponseSchema.parse(response);
+};

--- a/apps/web/src/features/search/components/global-search/GlobalSearchResults.tsx
+++ b/apps/web/src/features/search/components/global-search/GlobalSearchResults.tsx
@@ -186,7 +186,7 @@ export const GlobalSearchResults = ({
         <p className="mx-1 border border-border/70 px-3 py-3 font-mono text-xs text-muted-foreground">
           {isScopedMode
             ? "No matches found for this scope."
-            : "No matches found across users, cinema, and serials."}
+            : "No matches found across users, movies, and TV shows."}
         </p>
       ) : null}
     </div>

--- a/apps/web/src/features/search/components/global-search/mappers.ts
+++ b/apps/web/src/features/search/components/global-search/mappers.ts
@@ -1,4 +1,5 @@
 import type { UserSearchResult } from "@/features/profile/api";
+import type { UnifiedSearchResult } from "@/features/search/api";
 import type { TmdbSearchSeries } from "@/features/serials/api";
 import type { TmdbSearchMovie } from "@/types/api";
 import type { CinemaResultEntry, SerialResultEntry, UserResultEntry } from "./types";
@@ -32,6 +33,30 @@ export const toSerialEntry = (series: TmdbSearchSeries): SerialResultEntry => ({
   posterPath: series.poster_path,
   firstAirDate: series.first_air_date,
 });
+
+export const toTitleEntry = (
+  result: UnifiedSearchResult,
+): CinemaResultEntry | SerialResultEntry => {
+  if (result.mediaType === "movie") {
+    return {
+      kind: "cinema",
+      id: `cinema-${result.tmdbId}`,
+      tmdbId: result.tmdbId,
+      title: result.title,
+      posterPath: result.posterPath,
+      releaseDate: result.releaseDate ?? "",
+    };
+  }
+
+  return {
+    kind: "serials",
+    id: `serials-${result.tmdbId}`,
+    tmdbId: result.tmdbId,
+    title: result.title,
+    posterPath: result.posterPath,
+    firstAirDate: result.releaseDate ?? "",
+  };
+};
 
 export const toYear = (value: string | null | undefined): string | null => {
   if (!value || value.length < 4) {

--- a/apps/web/src/features/search/components/global-search/types.ts
+++ b/apps/web/src/features/search/components/global-search/types.ts
@@ -5,6 +5,9 @@ import type { TmdbSearchMovie } from "@/types/api";
 
 export type SearchMode = "home" | "scoped";
 export type ScopedTarget = "users" | "cinema" | "serials";
+// Home (unscoped) sections also include a merged movies+TV section, which
+// isn't an individually enterable scope the way ScopedTarget values are.
+export type SectionTarget = ScopedTarget | "titles";
 
 export type UserResultEntry = {
   kind: "users";
@@ -38,7 +41,7 @@ export type SearchResultEntry =
   | SerialResultEntry;
 
 export type SearchSection = {
-  target: ScopedTarget;
+  target: SectionTarget;
   label: string;
   items: SearchResultEntry[];
   isLoading: boolean;

--- a/apps/web/src/features/search/components/global-search/useGlobalSearchState.ts
+++ b/apps/web/src/features/search/components/global-search/useGlobalSearchState.ts
@@ -7,12 +7,13 @@ import {
 } from "react";
 import { useMovieSearch } from "@/features/films/hooks/useMovies";
 import { useUserSearch } from "@/features/profile/hooks/useProfile";
+import { useTitleSearch } from "@/features/search/hooks/useSearch";
 import { useSerialSearch } from "@/features/serials/hooks/useSerials";
 import {
   MAX_RESULTS_PER_SECTION,
   MIN_QUERY_LENGTH,
 } from "./constants";
-import { toCinemaEntry, toSerialEntry, toUserEntry } from "./mappers";
+import { toCinemaEntry, toSerialEntry, toTitleEntry, toUserEntry } from "./mappers";
 import type {
   ScopedTarget,
   SearchMode,
@@ -60,18 +61,23 @@ export const useGlobalSearchState = (): GlobalSearchState => {
     shouldRunSearch && (!isScopedMode || scopedTarget === "users")
       ? deferredQuery
       : "";
+  // Cinema/serials queries only run in scoped (single-type drill-down) mode —
+  // the unscoped home view uses the merged titlesQuery below instead.
   const cinemaQueryValue =
-    shouldRunSearch && (!isScopedMode || scopedTarget === "cinema")
+    shouldRunSearch && isScopedMode && scopedTarget === "cinema"
       ? deferredQuery
       : "";
   const serialsQueryValue =
-    shouldRunSearch && (!isScopedMode || scopedTarget === "serials")
+    shouldRunSearch && isScopedMode && scopedTarget === "serials"
       ? deferredQuery
       : "";
+  const titlesQueryValue =
+    shouldRunSearch && !isScopedMode ? deferredQuery : "";
 
   const usersQuery = useUserSearch(usersQueryValue, MAX_RESULTS_PER_SECTION);
   const cinemaQuery = useMovieSearch(cinemaQueryValue);
   const serialsQuery = useSerialSearch(serialsQueryValue);
+  const titlesQuery = useTitleSearch(titlesQueryValue);
 
   const userEntries = useMemo(() => {
     return (usersQuery.data ?? []).slice(0, MAX_RESULTS_PER_SECTION).map(toUserEntry);
@@ -84,6 +90,10 @@ export const useGlobalSearchState = (): GlobalSearchState => {
   const serialEntries = useMemo(() => {
     return (serialsQuery.data ?? []).slice(0, MAX_RESULTS_PER_SECTION).map(toSerialEntry);
   }, [serialsQuery.data]);
+
+  const titleEntries = useMemo(() => {
+    return (titlesQuery.data ?? []).slice(0, MAX_RESULTS_PER_SECTION).map(toTitleEntry);
+  }, [titlesQuery.data]);
 
   const sections = useMemo<SearchSection[]>(() => {
     if (!shouldRunSearch) {
@@ -135,18 +145,11 @@ export const useGlobalSearchState = (): GlobalSearchState => {
         isError: usersQuery.isError,
       },
       {
-        target: "cinema",
-        label: "Cinema",
-        items: cinemaEntries,
-        isLoading: cinemaQuery.isFetching,
-        isError: cinemaQuery.isError,
-      },
-      {
-        target: "serials",
-        label: "Serials",
-        items: serialEntries,
-        isLoading: serialsQuery.isFetching,
-        isError: serialsQuery.isError,
+        target: "titles",
+        label: "Titles",
+        items: titleEntries,
+        isLoading: titlesQuery.isFetching,
+        isError: titlesQuery.isError,
       },
     ];
   }, [
@@ -156,12 +159,15 @@ export const useGlobalSearchState = (): GlobalSearchState => {
     userEntries,
     cinemaEntries,
     serialEntries,
+    titleEntries,
     usersQuery.isFetching,
     usersQuery.isError,
     cinemaQuery.isFetching,
     cinemaQuery.isError,
     serialsQuery.isFetching,
     serialsQuery.isError,
+    titlesQuery.isFetching,
+    titlesQuery.isError,
   ]);
 
   const sectionOffsets = useMemo(() => {

--- a/apps/web/src/features/search/hooks/useSearch.ts
+++ b/apps/web/src/features/search/hooks/useSearch.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { searchTitles } from "@/features/search/api";
+
+export const searchKeys = {
+  titles: (query: string) => ["search", "titles", query] as const,
+};
+
+export const useTitleSearch = (query: string) =>
+  useQuery({
+    queryKey: searchKeys.titles(query),
+    queryFn: ({ signal }) => searchTitles(query, { signal }),
+    enabled: query.trim().length >= 2,
+  });

--- a/apps/web/src/features/settings/components/SettingsTabs.tsx
+++ b/apps/web/src/features/settings/components/SettingsTabs.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { useMatchRoute } from "@tanstack/react-router";
-import { Download, Layers, Lock, Palette, Trophy, User } from "lucide-react";
+import { Download, Layers, Lock, Palette, ShieldOff, Trophy, User } from "lucide-react";
 import { settingsSections } from "@/features/settings/model/settings.constants";
 
 const tabClass =
@@ -12,6 +12,7 @@ const iconBySection = {
   auth: Lock,
   genres: Layers,
   favorites: Trophy,
+  blocked: ShieldOff,
   data: Download,
 } as const;
 

--- a/apps/web/src/features/settings/components/sections/SettingsBlockedSection.tsx
+++ b/apps/web/src/features/settings/components/sections/SettingsBlockedSection.tsx
@@ -1,0 +1,157 @@
+import { Link } from "@tanstack/react-router";
+import { Spinner } from "@/components/ui/spinner";
+import { FeedActorAvatar } from "@/features/feed/components/FeedActorAvatar";
+import type { ModeratedUser } from "@/features/moderation/api";
+import {
+  useBlockedUsers,
+  useMutedUsers,
+  useUnblockUser,
+  useUnmuteUser,
+} from "@/features/moderation/hooks/useModeration";
+
+const rowClass =
+  "flex items-center gap-3 border-b px-4 py-3 last:border-0 settings-shell-row-border";
+
+const UnblockButton = ({ username }: { username: string }) => {
+  const unblockMutation = useUnblockUser(username);
+
+  return (
+    <button
+      type="button"
+      disabled={unblockMutation.isPending}
+      onClick={() => unblockMutation.mutate()}
+      className="shrink-0 border px-2.5 py-1 font-mono text-[9px] uppercase tracking-[0.12em] transition-colors settings-shell-border settings-shell-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {unblockMutation.isPending ? "Saving" : "Unblock"}
+    </button>
+  );
+};
+
+const UnmuteButton = ({ username }: { username: string }) => {
+  const unmuteMutation = useUnmuteUser(username);
+
+  return (
+    <button
+      type="button"
+      disabled={unmuteMutation.isPending}
+      onClick={() => unmuteMutation.mutate()}
+      className="shrink-0 border px-2.5 py-1 font-mono text-[9px] uppercase tracking-[0.12em] transition-colors settings-shell-border settings-shell-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {unmuteMutation.isPending ? "Saving" : "Unmute"}
+    </button>
+  );
+};
+
+const UserRow = ({
+  moderatedUser,
+  action,
+}: {
+  moderatedUser: ModeratedUser;
+  action: "unblock" | "unmute";
+}) => {
+  const avatarUrl = moderatedUser.avatarUrl ?? moderatedUser.image ?? null;
+  const initial = moderatedUser.username.slice(0, 1).toUpperCase();
+
+  return (
+    <li className={rowClass}>
+      <Link to="/profile/$username" params={{ username: moderatedUser.username }} className="shrink-0">
+        <FeedActorAvatar
+          avatarUrl={avatarUrl}
+          username={moderatedUser.username}
+          initial={initial}
+          className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden border settings-shell-border"
+        />
+      </Link>
+
+      <Link
+        to="/profile/$username"
+        params={{ username: moderatedUser.username }}
+        className="min-w-0 flex-1"
+      >
+        <p className="truncate font-mono text-sm font-medium settings-shell-accent">
+          {moderatedUser.displayUsername ?? moderatedUser.username}
+        </p>
+        <p className="truncate font-mono text-[10px] settings-shell-muted">
+          @{moderatedUser.username}
+        </p>
+      </Link>
+
+      {action === "unblock" ? (
+        <UnblockButton username={moderatedUser.username} />
+      ) : (
+        <UnmuteButton username={moderatedUser.username} />
+      )}
+    </li>
+  );
+};
+
+export const SettingsBlockedSection = () => {
+  const blockedQuery = useBlockedUsers();
+  const mutedQuery = useMutedUsers();
+
+  return (
+    <div className="space-y-6">
+      <div className="border settings-shell-border settings-shell-panel">
+        <div className="border-b px-6 py-4 settings-shell-row-border">
+          <p className="mb-1 font-mono text-[10px] uppercase tracking-[0.16em] settings-shell-accent">
+            Blocked Users
+          </p>
+          <p className="font-mono text-[10px] settings-shell-muted">
+            Blocked users can't follow you, and their activity is hidden from your feed.
+          </p>
+        </div>
+
+        {blockedQuery.isPending ? (
+          <div className="flex items-center justify-center py-10">
+            <Spinner />
+          </div>
+        ) : blockedQuery.isError ? (
+          <p className="py-10 text-center font-mono text-xs settings-shell-muted">
+            Could not load blocked users.
+          </p>
+        ) : blockedQuery.data.length === 0 ? (
+          <p className="py-10 text-center font-mono text-xs settings-shell-muted">
+            You haven't blocked anyone.
+          </p>
+        ) : (
+          <ul>
+            {blockedQuery.data.map((moderatedUser) => (
+              <UserRow key={moderatedUser.id} moderatedUser={moderatedUser} action="unblock" />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="border settings-shell-border settings-shell-panel">
+        <div className="border-b px-6 py-4 settings-shell-row-border">
+          <p className="mb-1 font-mono text-[10px] uppercase tracking-[0.16em] settings-shell-accent">
+            Muted Users
+          </p>
+          <p className="font-mono text-[10px] settings-shell-muted">
+            Muted users don't know you've muted them. Their activity is hidden from your feed only.
+          </p>
+        </div>
+
+        {mutedQuery.isPending ? (
+          <div className="flex items-center justify-center py-10">
+            <Spinner />
+          </div>
+        ) : mutedQuery.isError ? (
+          <p className="py-10 text-center font-mono text-xs settings-shell-muted">
+            Could not load muted users.
+          </p>
+        ) : mutedQuery.data.length === 0 ? (
+          <p className="py-10 text-center font-mono text-xs settings-shell-muted">
+            You haven't muted anyone.
+          </p>
+        ) : (
+          <ul>
+            {mutedQuery.data.map((moderatedUser) => (
+              <UserRow key={moderatedUser.id} moderatedUser={moderatedUser} action="unmute" />
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/features/settings/model/settings.constants.ts
+++ b/apps/web/src/features/settings/model/settings.constants.ts
@@ -49,6 +49,12 @@ export const settingsSections: SettingsSectionDefinition[] = [
     description: "Top picks showcased on your profile.",
   },
   {
+    id: "blocked",
+    to: "/settings/blocked",
+    label: "Blocked",
+    description: "Manage blocked and muted users.",
+  },
+  {
     id: "data",
     to: "/settings/data",
     label: "Data",

--- a/apps/web/src/features/settings/model/settings.types.ts
+++ b/apps/web/src/features/settings/model/settings.types.ts
@@ -4,6 +4,7 @@ export type SettingsSectionId =
   | "auth"
   | "genres"
   | "favorites"
+  | "blocked"
   | "data";
 
 export type SettingsSectionTo =
@@ -12,6 +13,7 @@ export type SettingsSectionTo =
   | "/settings/auth"
   | "/settings/genres"
   | "/settings/favorites"
+  | "/settings/blocked"
   | "/settings/data";
 
 export type SettingsSectionDefinition = {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as SettingsProfileRouteImport } from './routes/settings/profile'
 import { Route as SettingsGenresRouteImport } from './routes/settings/genres'
 import { Route as SettingsFavoritesRouteImport } from './routes/settings/favorites'
 import { Route as SettingsDataRouteImport } from './routes/settings/data'
+import { Route as SettingsBlockedRouteImport } from './routes/settings/blocked'
 import { Route as SettingsAuthRouteImport } from './routes/settings/auth'
 import { Route as SerialsTmdbIdRouteImport } from './routes/serials/$tmdbId'
 import { Route as FilmsTmdbIdRouteImport } from './routes/films/$tmdbId'
@@ -118,6 +119,11 @@ const SettingsFavoritesRoute = SettingsFavoritesRouteImport.update({
 const SettingsDataRoute = SettingsDataRouteImport.update({
   id: '/data',
   path: '/data',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsBlockedRoute = SettingsBlockedRouteImport.update({
+  id: '/blocked',
+  path: '/blocked',
   getParentRoute: () => SettingsRouteRoute,
 } as any)
 const SettingsAuthRoute = SettingsAuthRouteImport.update({
@@ -238,6 +244,7 @@ export interface FileRoutesByFullPath {
   '/films/$tmdbId': typeof FilmsTmdbIdRoute
   '/serials/$tmdbId': typeof SerialsTmdbIdRoute
   '/settings/auth': typeof SettingsAuthRoute
+  '/settings/blocked': typeof SettingsBlockedRoute
   '/settings/data': typeof SettingsDataRoute
   '/settings/favorites': typeof SettingsFavoritesRoute
   '/settings/genres': typeof SettingsGenresRoute
@@ -273,6 +280,7 @@ export interface FileRoutesByTo {
   '/films/$tmdbId': typeof FilmsTmdbIdRoute
   '/serials/$tmdbId': typeof SerialsTmdbIdRoute
   '/settings/auth': typeof SettingsAuthRoute
+  '/settings/blocked': typeof SettingsBlockedRoute
   '/settings/data': typeof SettingsDataRoute
   '/settings/favorites': typeof SettingsFavoritesRoute
   '/settings/genres': typeof SettingsGenresRoute
@@ -311,6 +319,7 @@ export interface FileRoutesById {
   '/films/$tmdbId': typeof FilmsTmdbIdRoute
   '/serials/$tmdbId': typeof SerialsTmdbIdRoute
   '/settings/auth': typeof SettingsAuthRoute
+  '/settings/blocked': typeof SettingsBlockedRoute
   '/settings/data': typeof SettingsDataRoute
   '/settings/favorites': typeof SettingsFavoritesRoute
   '/settings/genres': typeof SettingsGenresRoute
@@ -350,6 +359,7 @@ export interface FileRouteTypes {
     | '/films/$tmdbId'
     | '/serials/$tmdbId'
     | '/settings/auth'
+    | '/settings/blocked'
     | '/settings/data'
     | '/settings/favorites'
     | '/settings/genres'
@@ -385,6 +395,7 @@ export interface FileRouteTypes {
     | '/films/$tmdbId'
     | '/serials/$tmdbId'
     | '/settings/auth'
+    | '/settings/blocked'
     | '/settings/data'
     | '/settings/favorites'
     | '/settings/genres'
@@ -422,6 +433,7 @@ export interface FileRouteTypes {
     | '/films/$tmdbId'
     | '/serials/$tmdbId'
     | '/settings/auth'
+    | '/settings/blocked'
     | '/settings/data'
     | '/settings/favorites'
     | '/settings/genres'
@@ -573,6 +585,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsDataRouteImport
       parentRoute: typeof SettingsRouteRoute
     }
+    '/settings/blocked': {
+      id: '/settings/blocked'
+      path: '/blocked'
+      fullPath: '/settings/blocked'
+      preLoaderRoute: typeof SettingsBlockedRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
     '/settings/auth': {
       id: '/settings/auth'
       path: '/auth'
@@ -718,6 +737,7 @@ declare module '@tanstack/react-router' {
 
 interface SettingsRouteRouteChildren {
   SettingsAuthRoute: typeof SettingsAuthRoute
+  SettingsBlockedRoute: typeof SettingsBlockedRoute
   SettingsDataRoute: typeof SettingsDataRoute
   SettingsFavoritesRoute: typeof SettingsFavoritesRoute
   SettingsGenresRoute: typeof SettingsGenresRoute
@@ -728,6 +748,7 @@ interface SettingsRouteRouteChildren {
 
 const SettingsRouteRouteChildren: SettingsRouteRouteChildren = {
   SettingsAuthRoute: SettingsAuthRoute,
+  SettingsBlockedRoute: SettingsBlockedRoute,
   SettingsDataRoute: SettingsDataRoute,
   SettingsFavoritesRoute: SettingsFavoritesRoute,
   SettingsGenresRoute: SettingsGenresRoute,

--- a/apps/web/src/routes/admin/index.tsx
+++ b/apps/web/src/routes/admin/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { PageWrapper } from "@/components/layout/PageWrapper";
-import { AdminPlaceholder } from "@/features/admin/components/AdminPlaceholder";
+import { AdminDashboardPage } from "@/features/admin/components/AdminDashboardPage";
 import { requireAdminUser } from "@/lib/router/auth-guards";
 
 export const Route = createFileRoute("/admin/")({
@@ -15,8 +15,8 @@ export const Route = createFileRoute("/admin/")({
 
 function AdminPage() {
   return (
-    <PageWrapper title="Admin" subtitle="Phase 4 management tools">
-      <AdminPlaceholder />
+    <PageWrapper title="Admin" subtitle="Moderation reports and user directory">
+      <AdminDashboardPage />
     </PageWrapper>
   );
 }

--- a/apps/web/src/routes/settings/blocked.tsx
+++ b/apps/web/src/routes/settings/blocked.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SettingsBlockedSection } from "@/features/settings/components/sections/SettingsBlockedSection";
+
+export const Route = createFileRoute("/settings/blocked")({
+  component: SettingsBlockedPage,
+});
+
+function SettingsBlockedPage() {
+  return <SettingsBlockedSection />;
+}


### PR DESCRIPTION
## Summary
Closes #20. All 5 sub-features on one branch per direction:

- **Unified search:** new `GET /api/search` merges movie+TV search (parallel TMDB calls, popularity-sorted). The global search dialog's home view now shows one merged "Titles" section instead of separate Cinema/Serials sections; scoped single-type search is unchanged.
- **Block/Mute:** new `user_block`/`user_mute` tables mirroring the existing `follow` table. Blocking severs any existing follow relationship in both directions and blocks re-following; muting is silent and leaves follows untouched. Both are excluded from the following feed. Profile page gets Mute/Block buttons; Settings gets a new "Blocked" page.
- **Notifications:** new stored `notification` table + module. Hooked into follow, review/post/activity likes, and review/post comments (no self-notifications). No WebSocket/SSE infra exists anywhere in this app, so this is polling-based (30s), not push. New bell dropdown in the navbar.
- **Reporting:** new `report` table (content snapshot at submit time, reason category, status). Users can report a review or post from its detail view / feed card; submission is idempotent per reporter+target.
- **Admin dashboard:** replaces the "Phase 4" placeholder at `/admin` with a real Reports queue (dismiss/resolve/remove-content) and a read-only, searchable user directory. Scoped to view-only user management — ban/suspend would need a new schema field and auth-wide enforcement well beyond this issue.

## Test plan
- [x] `bun run typecheck` / `lint` / `lint:arch` (api + web) clean throughout
- [x] `bun run test:ci` — 61/61 backend integration tests pass (includes new coverage for search, block/mute + follow/feed interaction, notifications triggers, reports lifecycle, admin actions)
- [x] `bun run test` — 8/8 frontend tests pass
- [x] `bun run build` succeeds
- [x] Manually verified live via `curl` against a running dev server: unified search endpoint (merged, popularity-sorted, correct `mediaType` tags), moderation endpoints (401/403/404 paths), notification triggers
- [ ] Visual browser walkthrough not done this session (no browser tool available) — worth a manual pass before merge, especially the search dialog, block/mute buttons, notifications bell, and admin dashboard