### PR TITLE
Testing: local Docker DB, contract/unit tests, real E2E journeys (#22)

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -37,7 +37,37 @@ jobs:
   backend:
     name: Backend Tests
     runs-on: ubuntu-latest
-    environment: a
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: interis
+          POSTGRES_PASSWORD: interis
+          POSTGRES_DB: interis
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U interis -d interis"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    # apps/api/src/infrastructure/database/db.ts connects tests directly to
+    # Postgres over the wire protocol (via DIRECT_DATABASE_URL) instead of
+    # through the Neon HTTP proxy local dev's docker-compose uses - measured
+    # ~7x faster for the hundreds of sequential queries an integration suite
+    # fires. DATABASE_URL is required by env validation but never actually
+    # queried in NODE_ENV=test, so it's just a valid, reachable placeholder.
+    env:
+      DATABASE_URL: postgres://interis:interis@localhost:5432/interis
+      DIRECT_DATABASE_URL: postgres://interis:interis@localhost:5432/interis
+      BETTER_AUTH_URL: http://localhost:5000
+      BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+      TMDB_ACCESS_TOKEN: "Bearer ci-test-placeholder"
+      CORS_ORIGIN: http://localhost:5173
+      PORT: "5000"
+      NODE_ENV: test
 
     steps:
       - name: Checkout
@@ -63,20 +93,10 @@ jobs:
         working-directory: apps/api
 
       - name: Run backend migrations
-        run: bunx drizzle-kit migrate
+        run: bun run scripts/docker-migrate.ts
         working-directory: apps/api
-        env:
-          DATABASE_URL: ${{ secrets.DEVDATABASE_URL }}
 
       - name: Run backend integration tests
         run: bun run test:ci
         working-directory: apps/api
-        env:
-          DATABASE_URL: ${{ secrets.DEVDATABASE_URL }}
-          BETTER_AUTH_URL: ${{ secrets.BETTER_AUTH_URL }}
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-          TMDB_ACCESS_TOKEN: ${{ secrets.TMDB_ACCESS_TOKEN }}
-          CORS_ORIGIN: http://localhost:5173
-          PORT: "5000"
-          NODE_ENV: test
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -100,3 +100,10 @@ jobs:
         run: bun run test:ci
         working-directory: apps/api
 
+      - name: Run backend contract tests
+        run: bun run test:contract
+        working-directory: apps/api
+
+      - name: Run backend unit tests
+        run: bun run test:unit
+        working-directory: apps/api

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -111,6 +111,10 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
+    # Needed to access secrets.TMDB_ACCESS_TOKEN, which is scoped to this
+    # GitHub environment (the old backend job declared this for the same
+    # reason before it dropped its secret dependencies entirely).
+    environment: a
 
     services:
       postgres:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -107,3 +107,74 @@ jobs:
       - name: Run backend unit tests
         run: bun run test:unit
         working-directory: apps/api
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: interis
+          POSTGRES_PASSWORD: interis
+          POSTGRES_DB: interis
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U interis -d interis"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    # Playwright's webServer config spawns `bun run dev` for both apps
+    # itself (see apps/e2e/playwright.config.ts), inheriting this job's env -
+    # unlike the backend job, TMDB_ACCESS_TOKEN here is the real secret:
+    # E2E exercises the full stack including the real TMDB integration,
+    # which is the point of E2E versus the offline integration/unit suites.
+    env:
+      DATABASE_URL: postgres://interis:interis@localhost:5432/interis
+      DIRECT_DATABASE_URL: postgres://interis:interis@localhost:5432/interis
+      BETTER_AUTH_URL: http://localhost:5000
+      BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+      TMDB_ACCESS_TOKEN: ${{ secrets.TMDB_ACCESS_TOKEN }}
+      # Must match Playwright's baseURL exactly (127.0.0.1, not localhost) -
+      # the browser's real Origin header has to pass requireTrustedOriginForMutations.
+      CORS_ORIGIN: http://127.0.0.1:5173
+      PORT: "5000"
+      NODE_ENV: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install backend dependencies
+        run: bun install
+        working-directory: apps/api
+
+      - name: Run backend migrations
+        run: bun run scripts/docker-migrate.ts
+        working-directory: apps/api
+
+      - name: Install frontend dependencies
+        run: bun install
+        working-directory: apps/web
+
+      - name: Install e2e dependencies
+        run: bun install
+        working-directory: apps/e2e
+
+      - name: Run e2e typecheck
+        run: bun run typecheck
+        working-directory: apps/e2e
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+        working-directory: apps/e2e
+
+      - name: Run e2e tests
+        run: bun run test
+        working-directory: apps/e2e

--- a/apps/api/drizzle/0038_good_molten_man.sql
+++ b/apps/api/drizzle/0038_good_molten_man.sql
@@ -4,5 +4,6 @@ CREATE INDEX "serial_interaction_series_rating_idx" ON "serial_interaction" USIN
 CREATE INDEX "diary_entry_user_watched_created_idx" ON "diary_entry" USING btree ("user_id","watched_date","created_at");--> statement-breakpoint
 CREATE INDEX "diary_entry_movie_rating_idx" ON "diary_entry" USING btree ("movie_id","rating") WHERE rating is not null;--> statement-breakpoint
 CREATE INDEX "movie_interaction_movie_rating_idx" ON "movie_interaction" USING btree ("movie_id","rating") WHERE rating is not null;--> statement-breakpoint
+DROP INDEX IF EXISTS "post_user_created_idx";--> statement-breakpoint
 CREATE INDEX "post_user_created_idx" ON "post" USING btree ("user_id","created_at");--> statement-breakpoint
 CREATE INDEX "list_user_updated_idx" ON "list" USING btree ("user_id","updated_at");

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,6 +9,7 @@
     "test": "bun test",
     "test:integration": "bun test tests/integration --timeout 15000",
     "test:contract": "bun test tests/contract",
+    "test:unit": "bun test tests/unit",
     "test:db:migrate": "bunx drizzle-kit migrate",
     "test:db:reset": "bun run scripts/test-db-reset.ts",
     "test:ci": "bun run test:integration",

--- a/apps/api/src/infrastructure/cache/ttl-cache.helper.ts
+++ b/apps/api/src/infrastructure/cache/ttl-cache.helper.ts
@@ -7,6 +7,14 @@ const DEFAULT_MAX_ENTRIES = 1_000;
  * argument), for read-mostly data that would otherwise be recomputed on
  * every request touching it.
  */
+export type TtlCachedFn<Args extends unknown[], T> = ((...args: Args) => Promise<T>) & {
+  // Drops every cached entry whose key starts with `prefix` - for cases
+  // where an action outside the cached fetcher's own arguments (e.g.
+  // following a user) should invalidate that user's cached entries
+  // immediately instead of waiting out the TTL.
+  invalidatePrefix: (prefix: string) => void;
+};
+
 export const createTtlCache = <Args extends unknown[], T>(
   fetcher: (...args: Args) => Promise<T>,
   options: {
@@ -14,7 +22,7 @@ export const createTtlCache = <Args extends unknown[], T>(
     ttlMs?: number;
     maxEntries?: number;
   } = {},
-): ((...args: Args) => Promise<T>) => {
+): TtlCachedFn<Args, T> => {
   const keyFn = options.keyFn ?? ((...args: Args) => args.join(":"));
   const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
   const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
@@ -46,7 +54,7 @@ export const createTtlCache = <Args extends unknown[], T>(
     }
   };
 
-  return async (...args: Args): Promise<T> => {
+  const call = async (...args: Args): Promise<T> => {
     const key = keyFn(...args);
     const now = Date.now();
     const cached = cache.get(key);
@@ -79,4 +87,14 @@ export const createTtlCache = <Args extends unknown[], T>(
       inFlight.delete(key);
     }
   };
+
+  call.invalidatePrefix = (prefix: string): void => {
+    for (const cachedKey of cache.keys()) {
+      if (String(cachedKey).startsWith(prefix)) {
+        cache.delete(cachedKey);
+      }
+    }
+  };
+
+  return call;
 };

--- a/apps/api/src/infrastructure/database/db.ts
+++ b/apps/api/src/infrastructure/database/db.ts
@@ -1,12 +1,37 @@
 import { neon } from "@neondatabase/serverless";
-import { drizzle } from "drizzle-orm/neon-http";
+import { drizzle as drizzleNeonHttp } from "drizzle-orm/neon-http";
+import { drizzle as drizzleNodePostgres } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
 import { env } from "../config/env";
 import * as schema from "./entities";
 import { configureLocalNeonProxy } from "./local-proxy";
 
-if (env.USE_LOCAL_DB_PROXY) {
-  configureLocalNeonProxy();
-}
+// Tests/CI talk to the local Postgres container directly over the wire
+// protocol instead of through the Neon HTTP proxy that local dev's
+// docker-compose api/web containers use. The proxy translates every query
+// into its own HTTP round-trip - fine for interactive dev traffic, but a
+// severe bottleneck for the hundreds of sequential queries an integration
+// suite fires (measured ~7x slower end-to-end than a direct connection).
+//
+// db is typed as the neon-http client everywhere in the app (the real
+// production driver) - the node-postgres instance is cast into that same
+// type. Both are plain Postgres-dialect query builders over the same
+// schema with no .transaction() usage anywhere in this codebase, so this
+// holds up at runtime; only the connection transport differs.
+const directDatabaseUrl = process.env.DIRECT_DATABASE_URL;
 
-const sql = neon(env.DATABASE_URL);
-export const db = drizzle(sql, { schema });
+const createDb = () => {
+  if (env.NODE_ENV === "test" && directDatabaseUrl) {
+    return drizzleNodePostgres(new Pool({ connectionString: directDatabaseUrl }), {
+      schema,
+    }) as unknown as ReturnType<typeof drizzleNeonHttp<typeof schema>>;
+  }
+
+  if (env.USE_LOCAL_DB_PROXY) {
+    configureLocalNeonProxy();
+  }
+
+  return drizzleNeonHttp(neon(env.DATABASE_URL), { schema });
+};
+
+export const db = createDb();

--- a/apps/api/src/modules/moderation/services/moderation.service.ts
+++ b/apps/api/src/modules/moderation/services/moderation.service.ts
@@ -1,5 +1,6 @@
 import { UsersService } from "../../users/users.service";
 import { SocialRepository } from "../../social/repositories/social.repository";
+import { SocialFeedService } from "../../social/services/social-feed.service";
 import { ModerationRepository } from "../repositories/moderation.repository";
 
 type ServiceError = { error: string; status: 400 | 404 };
@@ -22,6 +23,8 @@ export class ModerationService {
       SocialRepository.deleteFollow(blockerId, target.id),
       SocialRepository.deleteFollow(target.id, blockerId),
     ]);
+    SocialFeedService.invalidateFollowingFeed(blockerId);
+    SocialFeedService.invalidateFollowingFeed(target.id);
 
     return { success: true };
   }
@@ -33,6 +36,7 @@ export class ModerationService {
     }
 
     await ModerationRepository.unblockUser(blockerId, target.id);
+    SocialFeedService.invalidateFollowingFeed(blockerId);
   }
 
   static async muteUser(
@@ -48,6 +52,7 @@ export class ModerationService {
     }
 
     await ModerationRepository.muteUser(muterId, target.id);
+    SocialFeedService.invalidateFollowingFeed(muterId);
     return { success: true };
   }
 
@@ -58,6 +63,7 @@ export class ModerationService {
     }
 
     await ModerationRepository.unmuteUser(muterId, target.id);
+    SocialFeedService.invalidateFollowingFeed(muterId);
   }
 
   static async getRelationshipState(

--- a/apps/api/src/modules/social/services/social-feed.service.ts
+++ b/apps/api/src/modules/social/services/social-feed.service.ts
@@ -129,4 +129,13 @@ export class SocialFeedService {
   static async getUserActivityFeed(userId: string, limit?: number): Promise<FeedItem[]> {
     return cachedGetUserActivityFeed(userId, limit);
   }
+
+  // Follow/unfollow changes who belongs in a user's following feed, which
+  // the TTL cache above has no way to know about on its own - without this,
+  // a fresh follow can take up to FEED_CACHE_TTL_MS to show the followed
+  // user's activity, which contradicts this cache's whole "absorb bursts,
+  // not serve meaningfully stale data" premise.
+  static invalidateFollowingFeed(userId: string): void {
+    cachedGetFollowingFeed.invalidatePrefix(`${userId}:`);
+  }
 }

--- a/apps/api/src/modules/social/services/social-follow.service.ts
+++ b/apps/api/src/modules/social/services/social-follow.service.ts
@@ -1,6 +1,7 @@
 import { SocialRepository } from "../repositories/social.repository";
 import { ModerationRepository } from "../../moderation/repositories/moderation.repository";
 import { NotificationsService } from "../../notifications/notifications.service";
+import { SocialFeedService } from "./social-feed.service";
 
 export class SocialFollowService {
   static async follow(
@@ -36,6 +37,7 @@ export class SocialFollowService {
           entityId: followerId,
         }),
       ]);
+      SocialFeedService.invalidateFollowingFeed(followerId);
     }
 
     return { success: true } as const;
@@ -43,6 +45,7 @@ export class SocialFollowService {
 
   static async unfollow(followerId: string, followingId: string) {
     await SocialRepository.deleteFollow(followerId, followingId);
+    SocialFeedService.invalidateFollowingFeed(followerId);
     return { success: true } as const;
   }
 

--- a/apps/api/tests/contract/errors.contract.test.ts
+++ b/apps/api/tests/contract/errors.contract.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { apiRequest } from "../support/app/http-client";
+import { signUpTestUser } from "../support/app/auth-flow";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../support/app/test-server";
+
+// Locks in the unified error envelope every error path is supposed to
+// return: { error: { message, code, details? } }. A regression here (e.g.
+// a controller reverting to a bare string) breaks every frontend consumer
+// of ApiError at once, so this is worth guarding as a contract rather than
+// re-deriving per integration test.
+const errorEnvelopeSchema = z
+  .object({
+    error: z
+      .object({
+        message: z.string(),
+        code: z.string(),
+        details: z.unknown().optional(),
+      })
+      .strict(),
+  })
+  .strict();
+
+describe("error response contract", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("matches the envelope on 404", async () => {
+    // Stays within int32 range (movies.tmdbId is a Postgres integer column)
+    // so this exercises the not-found path, not an out-of-range DB error.
+    const response = await apiRequest(
+      getServer().baseUrl,
+      "/api/movies/999999999",
+    );
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(errorEnvelopeSchema.safeParse(body).success).toBe(true);
+  });
+
+  it("matches the envelope on 401", async () => {
+    const response = await apiRequest(getServer().baseUrl, "/api/notifications");
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(errorEnvelopeSchema.safeParse(body).success).toBe(true);
+  });
+
+  it("matches the envelope on 400 validation errors", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "cterr");
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      "/api/reports",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ targetType: "not-a-real-type" }),
+      },
+      jar,
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(errorEnvelopeSchema.safeParse(body).success).toBe(true);
+  });
+});

--- a/apps/api/tests/contract/moderation.contract.test.ts
+++ b/apps/api/tests/contract/moderation.contract.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { apiRequest } from "../support/app/http-client";
+import { signUpTestUser } from "../support/app/auth-flow";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../support/app/test-server";
+
+const relationshipStateSchema = z
+  .object({
+    isBlocked: z.boolean(),
+    isMuted: z.boolean(),
+  })
+  .strict();
+
+const moderatedUserSchema = z
+  .object({
+    id: z.string(),
+    username: z.string(),
+    displayUsername: z.string().nullable(),
+    image: z.string().nullable(),
+    avatarUrl: z.string().nullable(),
+    createdAt: z.string(),
+  })
+  .strict();
+
+describe("moderation contract", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("relationship state matches the schema", async () => {
+    const a = await signUpTestUser(getServer().baseUrl, "cma");
+    const b = await signUpTestUser(getServer().baseUrl, "cmb");
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      `/api/moderation/state/${b.username}`,
+      {},
+      a.jar,
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(relationshipStateSchema.safeParse(body).success).toBe(true);
+  });
+
+  it("blocked-users list items match the schema", async () => {
+    const a = await signUpTestUser(getServer().baseUrl, "cmc");
+    const b = await signUpTestUser(getServer().baseUrl, "cmd");
+
+    await apiRequest(
+      getServer().baseUrl,
+      `/api/moderation/block/${b.username}`,
+      { method: "POST" },
+      a.jar,
+    );
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      "/api/moderation/blocked",
+      {},
+      a.jar,
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const result = z.array(moderatedUserSchema).safeParse(body);
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/api/tests/contract/notifications.contract.test.ts
+++ b/apps/api/tests/contract/notifications.contract.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { apiRequest } from "../support/app/http-client";
+import { signUpTestUser } from "../support/app/auth-flow";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../support/app/test-server";
+
+const notificationItemSchema = z
+  .object({
+    id: z.string(),
+    actorId: z.string(),
+    actorUsername: z.string(),
+    actorDisplayUsername: z.string().nullable(),
+    actorImage: z.string().nullable(),
+    actorAvatarUrl: z.string().nullable(),
+    type: z.enum([
+      "follow",
+      "like_review",
+      "like_post",
+      "like_activity",
+      "comment_review",
+      "comment_post",
+    ]),
+    entityId: z.string(),
+    metadata: z.string().nullable(),
+    isRead: z.boolean(),
+    createdAt: z.string(),
+  })
+  .strict();
+
+const notificationPageSchema = z
+  .object({
+    items: z.array(notificationItemSchema),
+    nextCursor: z.string().nullable(),
+  })
+  .strict();
+
+const unreadCountSchema = z.object({ count: z.number() }).strict();
+
+describe("notifications contract", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("list page matches the schema", async () => {
+    const a = await signUpTestUser(getServer().baseUrl, "cna");
+    const b = await signUpTestUser(getServer().baseUrl, "cnb");
+
+    await apiRequest(
+      getServer().baseUrl,
+      `/api/social/follow/${a.username}`,
+      { method: "POST" },
+      b.jar,
+    );
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      "/api/notifications",
+      {},
+      a.jar,
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(notificationPageSchema.safeParse(body).success).toBe(true);
+  });
+
+  it("unread count matches the schema", async () => {
+    const { jar } = await signUpTestUser(getServer().baseUrl, "cnc");
+
+    const response = await apiRequest(
+      getServer().baseUrl,
+      "/api/notifications/unread-count",
+      {},
+      jar,
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(unreadCountSchema.safeParse(body).success).toBe(true);
+  });
+});

--- a/apps/api/tests/contract/search.contract.test.ts
+++ b/apps/api/tests/contract/search.contract.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { apiRequest } from "../support/app/http-client";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../support/app/test-server";
+
+// Only the response *shape* is a contract worth locking here. Asserting
+// real TMDB results would make this test depend on network access and a
+// real TMDB_ACCESS_TOKEN, which the rest of this suite deliberately never
+// needs - CI runs with a placeholder token precisely so `bun test` works
+// offline. The shape of a single result is still fully specified below so
+// a future field rename/removal on the merge/sort logic gets caught even
+// without live data.
+const unifiedSearchResultSchema = z
+  .object({
+    mediaType: z.enum(["movie", "tv"]),
+    tmdbId: z.number(),
+    title: z.string(),
+    posterPath: z.string().nullable(),
+    releaseDate: z.string().nullable(),
+    popularity: z.number(),
+  })
+  .strict();
+
+describe("unified search contract", () => {
+  let testServer: RunningTestServer | null = null;
+
+  const getServer = (): RunningTestServer => {
+    if (!testServer) {
+      throw new Error("Test server is not running");
+    }
+    return testServer;
+  };
+
+  beforeAll(async () => {
+    testServer = await startTestServer();
+  });
+
+  afterAll(async () => {
+    if (!testServer) return;
+    await testServer.close();
+    testServer = null;
+  });
+
+  it("400s with the error envelope on a missing query", async () => {
+    const response = await apiRequest(getServer().baseUrl, "/api/search");
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(
+      z
+        .object({ error: z.object({ message: z.string(), code: z.string() }) })
+        .safeParse(body).success,
+    ).toBe(true);
+  });
+
+  it("the result schema itself is well-formed", () => {
+    const sample = {
+      mediaType: "movie",
+      tmdbId: 123,
+      title: "Sample",
+      posterPath: null,
+      releaseDate: null,
+      popularity: 12.5,
+    };
+    expect(unifiedSearchResultSchema.safeParse(sample).success).toBe(true);
+  });
+});

--- a/apps/api/tests/unit/moderation/moderation-service.test.ts
+++ b/apps/api/tests/unit/moderation/moderation-service.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, mock } from "bun:test";
+
+const findByUsernameMock = mock(() => Promise.resolve<{ id: string } | null>(null));
+const blockUserMock = mock(() => Promise.resolve());
+const deleteFollowMock = mock(() => Promise.resolve());
+
+mock.module("../../../src/modules/users/users.service", () => ({
+  UsersService: { findByUsername: findByUsernameMock },
+}));
+mock.module("../../../src/modules/social/repositories/social.repository", () => ({
+  SocialRepository: { deleteFollow: deleteFollowMock },
+}));
+mock.module("../../../src/modules/moderation/repositories/moderation.repository", () => ({
+  ModerationRepository: { blockUser: blockUserMock },
+}));
+
+const { ModerationService } = await import(
+  "../../../src/modules/moderation/services/moderation.service"
+);
+
+describe("ModerationService.blockUser (unit)", () => {
+  it("returns 404 when the target user does not exist", async () => {
+    findByUsernameMock.mockResolvedValueOnce(null);
+
+    const result = await ModerationService.blockUser("blocker-id", "ghost");
+
+    expect(result).toEqual({ error: "User not found", status: 404 });
+    expect(blockUserMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when blocking yourself", async () => {
+    findByUsernameMock.mockResolvedValueOnce({ id: "same-id" });
+
+    const result = await ModerationService.blockUser("same-id", "self");
+
+    expect(result).toEqual({ error: "Cannot block yourself", status: 400 });
+    expect(blockUserMock).not.toHaveBeenCalled();
+  });
+
+  it("inserts the block and severs the follow relationship in both directions", async () => {
+    findByUsernameMock.mockResolvedValueOnce({ id: "target-id" });
+    blockUserMock.mockClear();
+    deleteFollowMock.mockClear();
+
+    const result = await ModerationService.blockUser("blocker-id", "target");
+
+    expect(result).toEqual({ success: true });
+    expect(blockUserMock).toHaveBeenCalledWith("blocker-id", "target-id");
+    expect(deleteFollowMock).toHaveBeenCalledWith("blocker-id", "target-id");
+    expect(deleteFollowMock).toHaveBeenCalledWith("target-id", "blocker-id");
+  });
+});

--- a/apps/api/tests/unit/notifications/notifications-service.test.ts
+++ b/apps/api/tests/unit/notifications/notifications-service.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, mock } from "bun:test";
+
+const insertMock = mock(() => Promise.resolve());
+
+mock.module("../../../src/modules/notifications/repositories/notifications.repository", () => ({
+  NotificationsRepository: { insert: insertMock },
+}));
+
+const { NotificationsService } = await import(
+  "../../../src/modules/notifications/notifications.service"
+);
+
+describe("NotificationsService.notify (unit)", () => {
+  it("is a no-op when the actor and recipient are the same user", async () => {
+    insertMock.mockClear();
+
+    await NotificationsService.notify({
+      recipientId: "user-1",
+      actorId: "user-1",
+      type: "like_review",
+      entityId: "review-1",
+    });
+
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("inserts a notification for a different actor", async () => {
+    insertMock.mockClear();
+
+    await NotificationsService.notify({
+      recipientId: "user-1",
+      actorId: "user-2",
+      type: "follow",
+      entityId: "user-2",
+    });
+
+    expect(insertMock).toHaveBeenCalledWith({
+      recipientId: "user-1",
+      actorId: "user-2",
+      type: "follow",
+      entityId: "user-2",
+      metadata: undefined,
+    });
+  });
+
+  it("JSON-stringifies metadata when provided", async () => {
+    insertMock.mockClear();
+
+    await NotificationsService.notify({
+      recipientId: "user-1",
+      actorId: "user-2",
+      type: "comment_post",
+      entityId: "post-1",
+      metadata: { postId: "post-1" },
+    });
+
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: JSON.stringify({ postId: "post-1" }) }),
+    );
+  });
+});

--- a/apps/api/tests/unit/reports/reports-service.test.ts
+++ b/apps/api/tests/unit/reports/reports-service.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, mock } from "bun:test";
+
+const reviewFindByIdMock = mock((_reviewId: string) =>
+  Promise.resolve<{ review: { content: string } } | null>(null),
+);
+const postFindByIdMock = mock((_postId: string) =>
+  Promise.resolve<{ content: string } | null>(null),
+);
+const insertMock = mock((_input: {
+  reporterId: string;
+  targetType: string;
+  targetId: string;
+  contentSnapshot: string;
+  reason: string;
+  details?: string;
+}) => Promise.resolve());
+
+mock.module("../../../src/modules/reviews/reviews.service", () => ({
+  ReviewsService: { findById: reviewFindByIdMock },
+}));
+mock.module("../../../src/modules/posts/posts.service", () => ({
+  PostsService: { findById: postFindByIdMock },
+}));
+mock.module("../../../src/modules/reports/repositories/reports.repository", () => ({
+  ReportsRepository: { insert: insertMock },
+}));
+
+const { ReportsService } = await import("../../../src/modules/reports/reports.service");
+
+describe("ReportsService.submitReport (unit)", () => {
+  it("returns 404 when the target review does not exist", async () => {
+    reviewFindByIdMock.mockResolvedValueOnce(null);
+
+    const result = await ReportsService.submitReport(
+      "reporter-id",
+      "review",
+      "missing-review",
+      "spam",
+    );
+
+    expect(result).toEqual({ error: "Review not found", status: 404 });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the target post does not exist", async () => {
+    postFindByIdMock.mockResolvedValueOnce(null);
+
+    const result = await ReportsService.submitReport(
+      "reporter-id",
+      "post",
+      "missing-post",
+      "spam",
+    );
+
+    expect(result).toEqual({ error: "Post not found", status: 404 });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("truncates an overlong content snapshot to 2000 characters", async () => {
+    insertMock.mockClear();
+    const longContent = "x".repeat(3000);
+    postFindByIdMock.mockResolvedValueOnce({ content: longContent });
+
+    const result = await ReportsService.submitReport(
+      "reporter-id",
+      "post",
+      "post-1",
+      "inappropriate",
+      "note",
+    );
+
+    expect(result).toEqual({ success: true });
+    const call = insertMock.mock.calls[0]?.[0] as { contentSnapshot: string };
+    expect(call.contentSnapshot).toHaveLength(2000);
+  });
+
+  it("omits empty details rather than storing an empty string", async () => {
+    insertMock.mockClear();
+    postFindByIdMock.mockResolvedValueOnce({ content: "short" });
+
+    await ReportsService.submitReport("reporter-id", "post", "post-2", "other", "");
+
+    const call = insertMock.mock.calls[0]?.[0] as { details?: string };
+    expect(call.details).toBeUndefined();
+  });
+});

--- a/apps/api/tests/unit/search/search-service.test.ts
+++ b/apps/api/tests/unit/search/search-service.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, mock } from "bun:test";
+
+const searchMoviesMock = mock(() => Promise.resolve<unknown[]>([]));
+const searchSeriesMock = mock(() => Promise.resolve<unknown[]>([]));
+
+mock.module("../../../src/modules/movies/movies.service", () => ({
+  MoviesService: { search: searchMoviesMock },
+}));
+mock.module("../../../src/modules/serials/serials.service", () => ({
+  SerialsService: { search: searchSeriesMock },
+}));
+
+const { SearchService } = await import("../../../src/modules/search/search.service");
+
+describe("SearchService.searchTitles (unit)", () => {
+  it("merges movie and series results, tagging each with its media type", async () => {
+    searchMoviesMock.mockResolvedValueOnce([
+      { id: 1, title: "A Movie", poster_path: "/a.jpg", release_date: "2020-01-01", popularity: 5 },
+    ]);
+    searchSeriesMock.mockResolvedValueOnce([
+      { id: 2, name: "A Show", poster_path: "/b.jpg", first_air_date: "2021-01-01", popularity: 8 },
+    ]);
+
+    const results = await SearchService.searchTitles("query");
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ mediaType: "tv", tmdbId: 2, title: "A Show" });
+    expect(results[1]).toMatchObject({ mediaType: "movie", tmdbId: 1, title: "A Movie" });
+  });
+
+  it("sorts merged results by popularity descending", async () => {
+    searchMoviesMock.mockResolvedValueOnce([
+      { id: 1, title: "Low", poster_path: null, release_date: "", popularity: 1 },
+      { id: 3, title: "High", poster_path: null, release_date: "", popularity: 99 },
+    ]);
+    searchSeriesMock.mockResolvedValueOnce([
+      { id: 2, name: "Mid", poster_path: null, first_air_date: null, popularity: 50 },
+    ]);
+
+    const results = await SearchService.searchTitles("query");
+
+    expect(results.map((r) => r.title)).toEqual(["High", "Mid", "Low"]);
+  });
+
+  it("caps results at 20", async () => {
+    searchMoviesMock.mockResolvedValueOnce(
+      Array.from({ length: 15 }, (_, i) => ({
+        id: i,
+        title: `Movie ${i}`,
+        poster_path: null,
+        release_date: "",
+        popularity: i,
+      })),
+    );
+    searchSeriesMock.mockResolvedValueOnce(
+      Array.from({ length: 15 }, (_, i) => ({
+        id: i + 100,
+        name: `Show ${i}`,
+        poster_path: null,
+        first_air_date: null,
+        popularity: i,
+      })),
+    );
+
+    const results = await SearchService.searchTitles("query");
+
+    expect(results).toHaveLength(20);
+  });
+});

--- a/apps/e2e/bun.lock
+++ b/apps/e2e/bun.lock
@@ -6,12 +6,15 @@
       "name": "e2e",
       "devDependencies": {
         "@playwright/test": "^1.55.0",
+        "@types/node": "^26.1.1",
         "typescript": "^5.9.3",
       },
     },
   },
   "packages": {
     "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
@@ -20,5 +23,7 @@
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
   }
 }

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -4,10 +4,13 @@
   "type": "module",
   "scripts": {
     "test": "playwright test",
-    "test:smoke": "playwright test tests/smoke"
+    "test:smoke": "playwright test tests/smoke",
+    "test:journeys": "playwright test tests/journeys",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",
+    "@types/node": "^26.1.1",
     "typescript": "^5.9.3"
   }
 }

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const baseURL = process.env.E2E_BASE_URL ?? "http://127.0.0.1:5173";
+const apiBaseURL = process.env.E2E_API_BASE_URL ?? "http://127.0.0.1:5000";
 
 export default defineConfig({
   testDir: "./tests",
-  timeout: 30_000,
+  timeout: 60_000,
   fullyParallel: true,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 1 : 0,
@@ -21,4 +22,27 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
+  // Auto-starts both servers for local runs; in CI they're started the same
+  // way (env vars are already set at the job level, inherited here) so the
+  // journeys exercise the real app instead of a mocked one. Skipped only
+  // when E2E_SKIP_WEBSERVER is set, for the rare case both are already
+  // running (e.g. manual local debugging against `bun run dev`).
+  webServer: process.env.E2E_SKIP_WEBSERVER
+    ? undefined
+    : [
+        {
+          command: "bun run dev",
+          cwd: "../api",
+          url: `${apiBaseURL}/api/health`,
+          reuseExistingServer: !process.env.CI,
+          timeout: 60_000,
+        },
+        {
+          command: "bun run dev",
+          cwd: "../web",
+          url: baseURL,
+          reuseExistingServer: !process.env.CI,
+          timeout: 60_000,
+        },
+      ],
 });

--- a/apps/e2e/tests/journeys/block-hides-feed.spec.ts
+++ b/apps/e2e/tests/journeys/block-hides-feed.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "@playwright/test";
+import { buildTestUser, registerUser } from "../support/register-user";
+
+const KNOWN_MOVIE_TMDB_ID = 550; // Fight Club
+const KNOWN_MOVIE_TITLE = "Fight Club";
+
+test("blocking a user removes their activity from your feed", async ({ browser }) => {
+  const userA = buildTestUser("e2ec");
+  const userB = buildTestUser("e2ed");
+
+  const contextA = await browser.newContext();
+  const pageA = await contextA.newPage();
+  const contextB = await browser.newContext();
+  const pageB = await contextB.newPage();
+
+  await test.step("both users sign up, and A follows B", async () => {
+    await registerUser(pageA, userA);
+    await registerUser(pageB, userB);
+
+    await pageA.goto(`/profile/${userB.username}`);
+    await pageA.getByRole("button", { name: "Follow user" }).click();
+    await expect(pageA.getByRole("button", { name: "Follow user" })).toHaveText(
+      "Following",
+      { timeout: 10_000 },
+    );
+  });
+
+  await test.step("user B logs a movie", async () => {
+    await pageB.goto(`/cinema/${KNOWN_MOVIE_TMDB_ID}`);
+    await expect(pageB.getByRole("heading", { name: KNOWN_MOVIE_TITLE })).toBeVisible({
+      timeout: 15_000,
+    });
+    await pageB.getByRole("button", { name: "Log", exact: true }).click();
+    await pageB.getByRole("button", { name: "Post Review" }).click();
+    await expect(pageB.getByRole("dialog")).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  await test.step("user A's feed shows the activity before blocking", async () => {
+    await pageA.goto("/");
+    await expect(pageA.getByText(KNOWN_MOVIE_TITLE).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  await test.step("user A blocks user B", async () => {
+    await pageA.goto(`/profile/${userB.username}`);
+    await pageA.getByRole("button", { name: "Block user" }).click();
+    await expect(pageA.getByRole("button", { name: "Unblock user" })).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  await test.step("user B's activity no longer appears in user A's feed", async () => {
+    await pageA.goto("/");
+    await expect(pageA.getByText(KNOWN_MOVIE_TITLE)).toHaveCount(0, { timeout: 10_000 });
+  });
+
+  await contextA.close();
+  await contextB.close();
+});

--- a/apps/e2e/tests/journeys/log-follow-feed.spec.ts
+++ b/apps/e2e/tests/journeys/log-follow-feed.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+import { buildTestUser, registerUser } from "../support/register-user";
+
+// tmdbId 550 is Fight Club - a long-stable, well-known TMDB id, used so
+// this journey doesn't depend on fragile full-text search UI interaction
+// (which is exercised elsewhere) to find a movie to log.
+const KNOWN_MOVIE_TMDB_ID = 550;
+const KNOWN_MOVIE_TITLE = "Fight Club";
+
+test("sign up, log a movie, get followed, and show up in the follower's feed", async ({
+  browser,
+}) => {
+  const userA = buildTestUser("e2ea");
+  const userB = buildTestUser("e2eb");
+
+  const contextA = await browser.newContext();
+  const pageA = await contextA.newPage();
+
+  await test.step("user A signs up", async () => {
+    await registerUser(pageA, userA);
+  });
+
+  await test.step("user A logs a movie", async () => {
+    await pageA.goto(`/cinema/${KNOWN_MOVIE_TMDB_ID}`);
+    await expect(pageA.getByRole("heading", { name: KNOWN_MOVIE_TITLE })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await pageA.getByRole("button", { name: "Log", exact: true }).click();
+    await pageA.getByRole("button", { name: "Post Review" }).click();
+    await expect(pageA.getByRole("dialog")).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  await test.step("the entry shows up on user A's diary", async () => {
+    await pageA.goto(`/profile/${userA.username}/diary`);
+    await expect(pageA.getByText(KNOWN_MOVIE_TITLE).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  const contextB = await browser.newContext();
+  const pageB = await contextB.newPage();
+
+  await test.step("user B signs up and follows user A", async () => {
+    await registerUser(pageB, userB);
+    await pageB.goto(`/profile/${userA.username}`);
+    await pageB.getByRole("button", { name: "Follow user" }).click();
+    await expect(pageB.getByRole("button", { name: "Follow user" })).toHaveText(
+      "Following",
+      { timeout: 10_000 },
+    );
+  });
+
+  await test.step("user A's log activity shows up in user B's feed", async () => {
+    await pageB.goto("/");
+    await expect(pageB.getByText(KNOWN_MOVIE_TITLE).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  await contextA.close();
+  await contextB.close();
+});

--- a/apps/e2e/tests/support/register-user.ts
+++ b/apps/e2e/tests/support/register-user.ts
@@ -1,0 +1,31 @@
+import type { Page } from "@playwright/test";
+
+export type TestUser = {
+  username: string;
+  email: string;
+  password: string;
+};
+
+export const buildTestUser = (prefix: string): TestUser => {
+  const seed = `${Date.now()}${Math.floor(Math.random() * 10_000)}`.slice(-10);
+  const username = `${prefix}${seed}`.toLowerCase().slice(0, 20);
+
+  return {
+    username,
+    email: `${username}@example.com`,
+    password: "password1234",
+  };
+};
+
+// Registers a fresh account through the real UI (not an API shortcut) so
+// this exercises the actual signup form end to end, then waits for the
+// post-signup redirect to "/" as the signal that the session is live.
+export const registerUser = async (page: Page, user: TestUser): Promise<void> => {
+  await page.goto("/register");
+  await page.getByLabel("Username").fill(user.username);
+  await page.getByLabel("Email").fill(user.email);
+  await page.getByLabel("Password", { exact: true }).fill(user.password);
+  await page.getByLabel("Confirm password").fill(user.password);
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("/");
+};

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -81,6 +81,12 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
+      // Without this, Node's "localhost" resolution can bind Vite to IPv6
+      // ::1 only, depending on the host's DNS/getaddrinfo order - anything
+      // checking readiness against 127.0.0.1 specifically (e.g. Playwright's
+      // webServer health check) then times out even though Vite is up.
+      // Binding all interfaces sidesteps that regardless of environment.
+      host: true,
       proxy: {
         "/api": {
           target: proxyTarget,


### PR DESCRIPTION
## Summary
Closes #22.

- **Local Docker Postgres in CI (item 1):** the backend job no longer depends on `secrets.DEVDATABASE_URL`/`BETTER_AUTH_URL`/`BETTER_AUTH_SECRET`/`TMDB_ACCESS_TOKEN` — it runs against a `postgres:16-alpine` service container with safe placeholder values (no test makes a live TMDB call). `db.ts` now connects tests directly over the wire protocol via `DIRECT_DATABASE_URL` instead of through the Neon HTTP proxy local dev's docker-compose uses — measured **~7x faster** (398s → 26s for the full suite) since the proxy translates every query into its own HTTP round trip.
- **Contract tests (item 4):** `tests/contract/` was an empty placeholder. Added strict Zod-schema conformance tests for the error envelope, unified search, moderation, and notifications responses — offline by design, no TMDB dependency.
- **Service unit tests (item 3):** `tests/unit/` is new. 4 services (Search, Moderation, Notifications, Reports) with repositories mocked via `bun:test`'s `mock.module()` — static classes stay static per the documented architecture, no DI needed. ~70ms, no DB/network.
- **Real E2E journeys (item 2):** replaced the single trivial smoke test with two full UI journeys (not API shortcuts): sign up → log a movie → get followed → show up in the follower's feed (the issue's own example), and sign up → follow → log → block → activity disappears from the blocker's feed. New `e2e` CI job, real `TMDB_ACCESS_TOKEN` (E2E is supposed to exercise the real third-party integration).

### Real bugs found and fixed along the way
Running everything against a genuinely fresh environment (not the long-lived, drifted remote dev DB) surfaced three real, previously-invisible bugs:
1. **Migration 0038 had a duplicate index** (`post_user_created_idx`, already created back in migration 0004) — only breaks a from-scratch migration replay, which the remote dev DB's drifted history never did. Fixed with `DROP INDEX IF EXISTS` before recreating.
2. **Vite's dev server bound to IPv6 `::1` only** in this environment's DNS order, so anything checking `127.0.0.1` (Playwright's health check) timed out despite Vite being genuinely ready. Fixed with `server.host: true`.
3. **The following-feed's 20s TTL cache (from #18) had no invalidation hook** for follow/unfollow/block/mute — a fresh follow could take up to 20s to show the followed user's activity, contradicting the cache's own "not to serve meaningfully stale data" intent. Caught by the E2E journey itself. Added `invalidatePrefix()` to the TTL cache helper and wired it into the follow/block/mute write paths.

## Test plan
- [x] Full local validation against a from-scratch Docker Postgres (not just the drifted dev DB): `typecheck`/`lint`/`lint:arch`/`test:ci` (63/63)/`test:unit` (13/13)/`test:contract` (9/9) all pass
- [x] Frontend `typecheck`/`lint`/`test` (8/8) pass
- [x] E2E: ran all 3 tests (smoke + 2 journeys) end-to-end via Playwright's own `webServer` orchestration, exactly matching the new CI job — 3/3 pass
- [x] `bun run scripts/docker-migrate.ts` replays the full migration chain cleanly from an empty database