### PR TITLE
UX & Polish: skeleton loaders, optimistic updates, empty-state CTAs, mobile grid fix

### DIFF
--- a/apps/web/src/features/diary/hooks/useDiary.ts
+++ b/apps/web/src/features/diary/hooks/useDiary.ts
@@ -3,7 +3,7 @@ import { authKeys } from "@/features/auth/hooks/useAuth";
 import { createDiaryEntry, getMyFilmLogs } from "@/features/diary/api";
 import { movieKeys } from "@/features/films/hooks/useMovies";
 import { profileKeys } from "@/features/profile/hooks/useProfile";
-import type { CreateDiaryEntryInput, MeProfile } from "@/types/api";
+import type { CreateDiaryEntryInput, MeProfile, MovieLog } from "@/types/api";
 
 export const diaryKeys = {
   all: ["diary"] as const,
@@ -21,6 +21,50 @@ export const useCreateDiaryEntry = () => {
 
   return useMutation({
     mutationFn: (input: CreateDiaryEntryInput) => createDiaryEntry(input),
+    onMutate: async (variables) => {
+      const logsKey = movieKeys.logs(variables.tmdbId);
+      await queryClient.cancelQueries({ queryKey: logsKey });
+
+      const previousLogs = queryClient.getQueryData<MovieLog[]>(logsKey);
+      const me = queryClient.getQueryData<MeProfile | null>(authKeys.me);
+
+      if (!me) {
+        return { logsKey, applied: false as const, previousLogs };
+      }
+
+      const now = new Date().toISOString();
+      const optimisticLog: MovieLog = {
+        diaryEntryId: `optimistic-${now}`,
+        watchedDate: variables.watchedDate,
+        rating: variables.rating ?? null,
+        rewatch: variables.rewatch ?? false,
+        createdAt: now,
+        username: me.username,
+        userDisplayName: me.name ?? me.username,
+        avatarUrl: me.avatarUrl ?? me.image ?? null,
+        reviewContent: variables.review ?? null,
+        reviewContainsSpoilers: variables.review ? (variables.containsSpoilers ?? false) : null,
+        reviewUpdatedAt: variables.review ? now : null,
+      };
+
+      queryClient.setQueryData<MovieLog[]>(logsKey, (old) => [
+        optimisticLog,
+        ...(old ?? []),
+      ]);
+
+      return { logsKey, applied: true as const, previousLogs };
+    },
+    onError: (_error, _variables, context) => {
+      if (!context?.applied) {
+        return;
+      }
+
+      if (context.previousLogs !== undefined) {
+        queryClient.setQueryData(context.logsKey, context.previousLogs);
+      } else {
+        queryClient.removeQueries({ queryKey: context.logsKey, exact: true });
+      }
+    },
     onSuccess: async (_data, variables) => {
       const me = queryClient.getQueryData<MeProfile | null>(authKeys.me);
       const tasks = [

--- a/apps/web/src/features/moderation/hooks/useModeration.ts
+++ b/apps/web/src/features/moderation/hooks/useModeration.ts
@@ -77,6 +77,20 @@ export const useUnblockUser = (username: string) => {
 
   return useMutation({
     mutationFn: () => unblockUser(username),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: stateKey });
+      const previous = queryClient.getQueryData<RelationshipState>(stateKey);
+      queryClient.setQueryData<RelationshipState>(stateKey, (old) => ({
+        isBlocked: false,
+        isMuted: old?.isMuted ?? false,
+      }));
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(stateKey, context.previous);
+      }
+    },
     onSettled: async () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: stateKey }),
@@ -123,6 +137,20 @@ export const useUnmuteUser = (username: string) => {
 
   return useMutation({
     mutationFn: () => unmuteUser(username),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: stateKey });
+      const previous = queryClient.getQueryData<RelationshipState>(stateKey);
+      queryClient.setQueryData<RelationshipState>(stateKey, (old) => ({
+        isBlocked: old?.isBlocked ?? false,
+        isMuted: false,
+      }));
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(stateKey, context.previous);
+      }
+    },
     onSettled: async () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: stateKey }),

--- a/apps/web/src/features/profile/components/LikedMediaGrid.tsx
+++ b/apps/web/src/features/profile/components/LikedMediaGrid.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Link } from "@tanstack/react-router";
 import { getPosterUrl } from "@/features/films/components/utils";
 import type { UserInteractionMovie } from "@/features/profile/api";
+import { PROFILE_MEDIA_GRID_CLASSES } from "@/features/profile/components/ProfileMediaGridSkeleton";
 import { getRelativeTime } from "@/features/profile/utils/profile.utils";
 
 export type MediaFilter = "all" | "cinema" | "serial";
@@ -33,7 +34,7 @@ export const LikedMediaGrid = ({
   }
 
   return (
-    <div className="grid grid-cols-5 gap-3 sm:grid-cols-4 lg:grid-cols-6">
+    <div className={PROFILE_MEDIA_GRID_CLASSES}>
       {filtered.map((item) => {
         const mediaRoute = routeByMediaType[item.mediaType];
         const card = (

--- a/apps/web/src/features/profile/components/ProfileMediaGridSkeleton.tsx
+++ b/apps/web/src/features/profile/components/ProfileMediaGridSkeleton.tsx
@@ -1,0 +1,15 @@
+export const PROFILE_MEDIA_GRID_CLASSES = "grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6";
+
+export const ProfileMediaGridSkeleton = ({ count = 12 }: { count?: number }) => {
+  return (
+    <div className={PROFILE_MEDIA_GRID_CLASSES}>
+      {Array.from({ length: count }).map((_, index) => (
+        <div key={`profile-media-skeleton-${index}`}>
+          <div className="aspect-2/3 animate-pulse border border-border/70 bg-card/25" />
+          <div className="mt-1.5 h-2.5 w-11/12 animate-pulse bg-border/40" />
+          <div className="mt-1 h-2 w-3/4 animate-pulse bg-border/30" />
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/apps/web/src/features/profile/components/ProfileMediaInteractionGridSection.tsx
+++ b/apps/web/src/features/profile/components/ProfileMediaInteractionGridSection.tsx
@@ -2,7 +2,14 @@ import { Link } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
 import type { LucideIcon } from "lucide-react";
 import { getPosterUrl } from "@/features/films/components/utils";
-import { ProfileTabEmptyState } from "@/features/profile/components/ProfileTabEmptyState";
+import {
+  PROFILE_MEDIA_GRID_CLASSES,
+  ProfileMediaGridSkeleton,
+} from "@/features/profile/components/ProfileMediaGridSkeleton";
+import {
+  ProfileTabEmptyState,
+  type ProfileTabEmptyStateCta,
+} from "@/features/profile/components/ProfileTabEmptyState";
 import type { UserInteractionMovie } from "@/features/profile/api";
 import { getRelativeTime } from "@/features/profile/utils/profile.utils";
 
@@ -36,13 +43,13 @@ const filterMatches = (item: UserInteractionMovie, filter: FavoritesFilter): boo
 };
 
 type ProfileMediaInteractionGridSectionProps = {
-  loadingLabel: string;
   errorLabel: string;
   sectionTitle: string;
   emptyState: {
     icon: LucideIcon;
     title: string;
     description: string;
+    cta?: ProfileTabEmptyStateCta;
   };
   interactionVerb: string;
   isPending: boolean;
@@ -54,7 +61,6 @@ type ProfileMediaInteractionGridSectionProps = {
 };
 
 export const ProfileMediaInteractionGridSection = ({
-  loadingLabel,
   errorLabel,
   sectionTitle,
   emptyState,
@@ -74,11 +80,7 @@ export const ProfileMediaInteractionGridSection = ({
 
   return (
     <>
-      {isPending ? (
-        <div className=" border border-border/60 bg-card/30 p-4 text-sm text-muted-foreground">
-          {loadingLabel}
-        </div>
-      ) : null}
+      {isPending ? <ProfileMediaGridSkeleton /> : null}
 
       {isError ? (
         <div className=" border border-border/60 bg-card/30 p-4 text-sm text-destructive">
@@ -91,6 +93,7 @@ export const ProfileMediaInteractionGridSection = ({
           icon={emptyState.icon}
           title={emptyState.title}
           description={emptyState.description}
+          cta={emptyState.cta}
         />
       ) : null}
 
@@ -139,7 +142,7 @@ export const ProfileMediaInteractionGridSection = ({
               No {activeFilter === "all" ? "items" : activeFilter} {interactionVerb} yet.
             </div>
           ) : (
-            <div className="grid grid-cols-5 gap-3 sm:grid-cols-4 lg:grid-cols-6">
+            <div className={PROFILE_MEDIA_GRID_CLASSES}>
               {filteredItems.map((item) => {
                 const mediaRoute = routeByMediaType[item.mediaType];
 

--- a/apps/web/src/features/profile/components/ProfileTabEmptyState.tsx
+++ b/apps/web/src/features/profile/components/ProfileTabEmptyState.tsx
@@ -1,21 +1,36 @@
+import { Link, type LinkProps } from "@tanstack/react-router";
 import type { LucideIcon } from "lucide-react";
+
+export type ProfileTabEmptyStateCta = LinkProps & {
+  label: string;
+};
 
 type ProfileTabEmptyStateProps = {
   title: string;
   description: string;
   icon: LucideIcon;
+  cta?: ProfileTabEmptyStateCta;
 };
 
 export const ProfileTabEmptyState = ({
   title,
   description,
   icon: Icon,
+  cta,
 }: ProfileTabEmptyStateProps) => {
   return (
     <div className=" border border-dashed border-border/70 py-16 text-center">
       <Icon className="mx-auto mb-4 h-8 w-8 text-muted-foreground/70" aria-hidden="true" />
       <h3 className="mb-2 text-base font-semibold text-foreground">{title}</h3>
       <p className="text-sm text-muted-foreground">{description}</p>
+      {cta ? (
+        <Link
+          {...cta}
+          className="mt-5 inline-flex items-center gap-2 border border-primary/45 bg-primary/10 px-4 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-primary transition-colors hover:bg-primary/15"
+        >
+          {cta.label}
+        </Link>
+      ) : null}
     </div>
   );
 };

--- a/apps/web/src/features/profile/components/ReviewCardSkeleton.tsx
+++ b/apps/web/src/features/profile/components/ReviewCardSkeleton.tsx
@@ -1,0 +1,28 @@
+export const ReviewCardSkeleton = () => {
+  return (
+    <article
+      className="border"
+      style={{
+        borderColor: "var(--profile-shell-border)",
+        background: "var(--profile-shell-panel)",
+      }}
+    >
+      <div className="grid gap-3 p-3 sm:p-4" style={{ gridTemplateColumns: "68px 1fr" }}>
+        <div
+          className="animate-pulse border bg-card/25"
+          style={{ width: 68, height: 102, borderColor: "var(--profile-shell-row-border)" }}
+        />
+
+        <div className="min-w-0 space-y-2.5">
+          <div className="h-4 w-2/3 animate-pulse bg-border/40" />
+          <div className="h-2.5 w-24 animate-pulse bg-border/30" />
+          <div className="space-y-1.5 pt-1">
+            <div className="h-2.5 w-full animate-pulse bg-border/25" />
+            <div className="h-2.5 w-5/6 animate-pulse bg-border/25" />
+            <div className="h-2.5 w-2/3 animate-pulse bg-border/25" />
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+};

--- a/apps/web/src/features/profile/components/diary/DiaryRowSkeleton.tsx
+++ b/apps/web/src/features/profile/components/diary/DiaryRowSkeleton.tsx
@@ -1,0 +1,24 @@
+export const DiaryRowSkeleton = () => {
+  return (
+    <div
+      className="grid grid-cols-[1fr] items-center gap-3 border-b px-2 py-3 md:grid-cols-[80px_48px_56px_1fr_80px_120px_32px_32px_32px]"
+      style={{ borderColor: "var(--profile-shell-row-border)" }}
+    >
+      <div className="hidden h-14 w-16 animate-pulse border border-border/40 bg-card/25 md:block" />
+      <div className="hidden h-5 w-6 animate-pulse bg-border/40 md:block" />
+      <div className="hidden h-14 w-10 animate-pulse border border-border/40 bg-card/25 md:block" />
+
+      <div className="min-w-0 space-y-2">
+        <div className="h-3 w-2/3 animate-pulse bg-border/40 md:hidden" />
+        <div className="h-4 w-3/4 animate-pulse bg-border/40" />
+        <div className="h-3 w-1/3 animate-pulse bg-border/30 md:hidden" />
+      </div>
+
+      <div className="hidden h-3 w-10 animate-pulse bg-border/30 md:block" />
+      <div className="hidden h-3 w-16 animate-pulse bg-border/30 md:block" />
+      <div className="hidden h-3.5 w-3.5 animate-pulse bg-border/30 md:block" />
+      <div className="hidden h-3.5 w-3.5 animate-pulse bg-border/30 md:block" />
+      <div className="hidden h-3.5 w-3.5 animate-pulse bg-border/30 md:block" />
+    </div>
+  );
+};

--- a/apps/web/src/features/profile/pages/ProfileDiaryPage.tsx
+++ b/apps/web/src/features/profile/pages/ProfileDiaryPage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { BookOpen } from "lucide-react";
 import { ProfileTabEmptyState } from "@/features/profile/components/ProfileTabEmptyState";
 import { DiaryRow } from "@/features/profile/components/diary/DiaryRow";
+import { DiaryRowSkeleton } from "@/features/profile/components/diary/DiaryRowSkeleton";
 import { DiaryTableHeader } from "@/features/profile/components/diary/DiaryTableHeader";
 import { toDiaryRows } from "@/features/profile/components/diary/diary-model";
 import { useUserDiary, useUserLikedFilms } from "@/features/profile/hooks/useProfile";
@@ -32,8 +33,11 @@ export const ProfileDiaryPage = ({ username }: ProfileDiaryPageProps) => {
   return (
     <>
       {diaryQuery.isPending ? (
-        <div className=" border border-border/60 bg-card/30 p-4 text-sm text-muted-foreground">
-          Loading diary...
+        <div className="space-y-0">
+          <DiaryTableHeader />
+          {Array.from({ length: 6 }).map((_, index) => (
+            <DiaryRowSkeleton key={`diary-row-skeleton-${index}`} />
+          ))}
         </div>
       ) : null}
 
@@ -48,6 +52,7 @@ export const ProfileDiaryPage = ({ username }: ProfileDiaryPageProps) => {
           icon={BookOpen}
           title="No diary activity yet"
           description="This profile has not logged or reviewed anything yet."
+          cta={{ label: "Browse Cinema", to: "/cinema" }}
         />
       ) : null}
 

--- a/apps/web/src/features/profile/pages/ProfileLikedPage.tsx
+++ b/apps/web/src/features/profile/pages/ProfileLikedPage.tsx
@@ -4,6 +4,7 @@ import { ProfileTabEmptyState } from "@/features/profile/components/ProfileTabEm
 import { LikedMediaGrid, type MediaFilter } from "@/features/profile/components/LikedMediaGrid";
 import { LikedListCard } from "@/features/profile/components/LikedListCard";
 import { LikedReviewCard } from "@/features/profile/components/LikedReviewCard";
+import { ProfileMediaGridSkeleton } from "@/features/profile/components/ProfileMediaGridSkeleton";
 import {
   useUserLikedFilms,
   useUserLikedLists,
@@ -139,9 +140,7 @@ export const ProfileLikedPage = ({ username }: ProfileLikedPageProps) => {
       {activeTab === "medias" ? (
         <>
           {mediasQuery.isPending ? (
-            <div className="border border-border/60 bg-card/30 p-4 text-sm text-muted-foreground">
-              Loading liked media...
-            </div>
+            <ProfileMediaGridSkeleton />
           ) : mediasQuery.isError ? (
             <div className="border border-border/60 bg-card/30 p-4 text-sm text-destructive">
               Could not load liked media.
@@ -151,6 +150,7 @@ export const ProfileLikedPage = ({ username }: ProfileLikedPageProps) => {
               icon={Heart}
               title="No liked media yet"
               description="This profile has not liked any films or series yet."
+              cta={{ label: "Browse Cinema", to: "/cinema" }}
             />
           ) : (
             <LikedMediaGrid items={mediaItems} filter={mediaFilter} />

--- a/apps/web/src/features/profile/pages/ProfileListsPage.tsx
+++ b/apps/web/src/features/profile/pages/ProfileListsPage.tsx
@@ -127,6 +127,11 @@ export const ProfileListsPage = ({ username }: ProfileListsPageProps) => {
               ? "Create your first list to organize films and series."
               : "This profile has not created any public lists yet."
           }
+          cta={
+            isOwnProfile
+              ? { label: "Create a List", to: "/profile/$username/lists/new", params: { username } }
+              : undefined
+          }
         />
       ) : filteredLists.length === 0 ? (
         <div className="border border-border/60 bg-card/30 px-4 py-3 font-mono text-[11px] text-muted-foreground">

--- a/apps/web/src/features/profile/pages/ProfileReviewsPage.tsx
+++ b/apps/web/src/features/profile/pages/ProfileReviewsPage.tsx
@@ -5,6 +5,7 @@ import { formatRatingLabel } from "@/lib/rating";
 import { getPosterUrl } from "@/features/films/components/utils";
 import type { UserReview } from "@/features/profile/api";
 import { ProfileTabEmptyState } from "@/features/profile/components/ProfileTabEmptyState";
+import { ReviewCardSkeleton } from "@/features/profile/components/ReviewCardSkeleton";
 import { useUserReviews } from "@/features/profile/hooks/useProfile";
 
 type ProfileReviewsPageProps = {
@@ -114,8 +115,10 @@ export const ProfileReviewsPage = ({ username }: ProfileReviewsPageProps) => {
   return (
     <>
       {reviewsQuery.isPending ? (
-        <div className=" border border-border/60 bg-card/30 p-4 text-sm text-muted-foreground">
-          Loading reviews...
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <ReviewCardSkeleton key={`review-skeleton-${index}`} />
+          ))}
         </div>
       ) : null}
 
@@ -130,6 +133,7 @@ export const ProfileReviewsPage = ({ username }: ProfileReviewsPageProps) => {
           icon={Star}
           title="No written reviews yet"
           description="This profile has not published any reviews yet."
+          cta={{ label: "Browse Cinema", to: "/cinema" }}
         />
       ) : null}
 

--- a/apps/web/src/features/profile/pages/ProfileWatchingPage.tsx
+++ b/apps/web/src/features/profile/pages/ProfileWatchingPage.tsx
@@ -34,6 +34,7 @@ export const ProfileWatchingPage = ({ username }: ProfileWatchingPageProps) => {
           icon={PlayCircle}
           title="Nothing in progress"
           description="This profile has not started a serial they haven't finished yet."
+          cta={{ label: "Browse Serials", to: "/serials" }}
         />
       ) : null}
 

--- a/apps/web/src/features/profile/pages/ProfileWatchlistPage.tsx
+++ b/apps/web/src/features/profile/pages/ProfileWatchlistPage.tsx
@@ -14,7 +14,6 @@ export const ProfileWatchlistPage = ({
 
   return (
     <ProfileMediaInteractionGridSection
-      loadingLabel="Loading watchlist..."
       errorLabel="Could not load watchlist."
       sectionTitle="Watchlist"
       interactionVerb="added"
@@ -22,6 +21,7 @@ export const ProfileWatchlistPage = ({
         icon: Bookmark,
         title: "No watchlist items yet",
         description: "This profile has not added anything to watchlist yet.",
+        cta: { label: "Browse Cinema", to: "/cinema" },
       }}
       isPending={watchlistQuery.isPending}
       isError={watchlistQuery.isError}


### PR DESCRIPTION
## Summary
- **Optimistic updates**: `useCreateDiaryEntry` now optimistically prepends the new entry to the movie's "Community logs" cache instead of waiting for a round-trip + refetch, with rollback on error. `useUnblockUser`/`useUnmuteUser` gained the same optimistic `onMutate`/`onError` their `useBlockUser`/`useMuteUser` counterparts already had.
- **Skeleton loaders**: replaced plain "Loading..." text boxes with layout-matched skeletons — a shared poster-grid skeleton (watchlist, liked-media), a diary-row skeleton, and a review-card skeleton.
- **Empty states**: `ProfileTabEmptyState` gained an optional CTA link, wired into diary/reviews/watching/watchlist/liked-media/lists empty states with a sensible destination (browse cinema/serials, create a list) where one exists.
- **Mobile polish**: fixed the watchlist/liked-media poster grid, which went 5→4→6 columns from mobile to desktop instead of ascending monotonically like every other grid in the app. Now 2→3→4→6, shared between both grids via one exported class constant.

Closes #24

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test`
- [x] `bun run build`
- [ ] Manual: throttle network, log a film, confirm the community-logs list updates immediately
- [ ] Manual: throttle network, unblock/unmute a user, confirm the button updates immediately
- [ ] Manual: check diary/reviews/watchlist/liked-media loading and empty states, and the watchlist/liked-media grid at mobile widths